### PR TITLE
AdbDevice handle abstraction

### DIFF
--- a/adb_shell/handle_base.py
+++ b/adb_shell/handle_base.py
@@ -1,0 +1,17 @@
+"""
+Implementation of Base class for use with AdbDevice
+"""
+
+
+class HandleBase(object):
+    def connect(self):
+        raise NotImplementedError()
+
+    def close(self):
+        raise NotImplementedError()
+
+    def bulk_read(self, *args):
+        raise NotImplementedError()
+
+    def bulk_write(self, *args):
+        raise NotImplementedError()

--- a/tests/test_adb_device.py
+++ b/tests/test_adb_device.py
@@ -41,18 +41,18 @@ class AdbMessageForTesting(AdbMessage):
 class TestAdbDevice(unittest.TestCase):
     def setUp(self):
         with patchers.patch_tcp_handle:
-            self.device = AdbDevice('IP:5555')
+            self.device = AdbDevice.from_tcp('IP:5555')
             self.device._handle._bulk_read = b''.join(patchers.BULK_READ_LIST)
 
     def tearDown(self):
         self.assertFalse(self.device._handle._bulk_read)
 
     def test_init(self):
-        device_with_banner = AdbDevice('IP:5555', 'banner')
+        device_with_banner = AdbDevice.from_tcp('IP:5555', banner='banner')
         self.assertEqual(device_with_banner._banner, 'banner')
 
         with patch('socket.gethostname', side_effect=Exception):
-            device_banner_unknown = AdbDevice('IP:5555')
+            device_banner_unknown = AdbDevice.from_tcp('IP:5555')
             self.assertEqual(device_banner_unknown._banner, 'unknown')
 
         self.device._handle._bulk_read = b''
@@ -656,7 +656,7 @@ class TestAdbDevice(unittest.TestCase):
 class TestAdbDeviceWithBanner(TestAdbDevice):
     def setUp(self):
         with patchers.patch_tcp_handle:
-            self.device = AdbDevice('IP:5555', 'banner')
+            self.device = AdbDevice.from_tcp('IP:5555', banner='banner')
             self.device._handle._bulk_read = b''.join(patchers.BULK_READ_LIST)
 
 
@@ -664,5 +664,5 @@ class TestAdbDeviceBannerError(TestAdbDevice):
     def setUp(self):
         with patch('socket.gethostname', side_effect=Exception):
             with patchers.patch_tcp_handle:
-                self.device = AdbDevice('IP:5555')
+                self.device = AdbDevice.from_tcp('IP:5555')
                 self.device._handle._bulk_read = b''.join(patchers.BULK_READ_LIST)

--- a/tests/test_tcp_handle.py
+++ b/tests/test_tcp_handle.py
@@ -11,7 +11,7 @@ class TestTcpHandle(unittest.TestCase):
         """Create a ``TcpHandle`` and connect to a TCP service.
 
         """
-        self.handle = TcpHandle('IP:5555')
+        self.handle = TcpHandle.from_socket_address('IP:5555')
         with patchers.patch_create_connection:
             self.handle.connect()
 
@@ -67,6 +67,6 @@ class TestTcpHandle2(TestTcpHandle):
         """Create a ``TcpHandle`` and connect to a TCP service.
 
         """
-        self.handle = TcpHandle('IP')
+        self.handle = TcpHandle.from_socket_address('IP')
         with patchers.patch_create_connection:
             self.handle.connect()


### PR DESCRIPTION
`TcpHandle` is now a subclass of `HandleBase`
`AdbDevice()` now takes a `HandleBase` instance
Original functionality provided by `AdbDevice.from_tcp()`

Refactored `TcpHandle` related `"serial"` references to `"socket_address"`