### PR TITLE
Fix port parameter of TestTcpHandle's TcpHandle to be int

### DIFF
--- a/tests/test_tcp_handle.py
+++ b/tests/test_tcp_handle.py
@@ -13,7 +13,7 @@ class TestTcpHandle(unittest.TestCase):
         """Create a ``TcpHandle`` and connect to a TCP service.
 
         """
-        self.handle = TcpHandle('host', '5555')
+        self.handle = TcpHandle('host', 5555)
         with patchers.PATCH_CREATE_CONNECTION:
             self.handle.connect()
 


### PR DESCRIPTION
Minor bug fix: `TcpHandle` expects `port` to be int, so `TestTcpHandle` should pass an `int` to the constructor.