### PR TITLE
Add auth callback parameter to adb_device.connect

### DIFF
--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -295,7 +295,7 @@ class AdbDevice(object):
             The time in seconds to wait for a ``b'CNXN'`` authentication response
         total_timeout_s : float
             The total time in seconds to wait for expected commands in :meth:`AdbDevice._read`
-        auth_callback : func, None
+        auth_callback : function, None
             Function callback invoked when the connection needs to be accepted on the device
 
         Returns

--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -265,7 +265,7 @@ class AdbDevice(object):
         self._available = False
         self._handle.close()
 
-    def connect(self, rsa_keys=None, timeout_s=None, auth_timeout_s=constants.DEFAULT_AUTH_TIMEOUT_S, total_timeout_s=constants.DEFAULT_TOTAL_TIMEOUT_S):
+    def connect(self, rsa_keys=None, timeout_s=None, auth_timeout_s=constants.DEFAULT_AUTH_TIMEOUT_S, total_timeout_s=constants.DEFAULT_TOTAL_TIMEOUT_S, auth_callback=None):
         """Establish an ADB connection to the device.
 
         1. Use the handle to establish a connection
@@ -295,6 +295,8 @@ class AdbDevice(object):
             The time in seconds to wait for a ``b'CNXN'`` authentication response
         total_timeout_s : float
             The total time in seconds to wait for expected commands in :meth:`AdbDevice._read`
+        auth_callback : func, None
+            Function callback invoked when the connection needs to be accepted on the device
 
         Returns
         -------
@@ -355,6 +357,9 @@ class AdbDevice(object):
         pubkey = rsa_keys[0].GetPublicKey()
         if not isinstance(pubkey, (bytes, bytearray)):
             pubkey = bytearray(pubkey, 'utf-8')
+
+        if auth_callback is not None:
+            auth_callback(self)
 
         msg = AdbMessage(constants.AUTH, constants.AUTH_RSAPUBLICKEY, 0, pubkey + b'\0')
         self._send(msg, adb_info)

--- a/tests/test_adb_device.py
+++ b/tests/test_adb_device.py
@@ -143,6 +143,22 @@ class TestAdbDevice(unittest.TestCase):
 
         self.assertTrue(self.device.connect([signer]))
 
+    def test_connect_with_new_key_and_callback(self):
+        with patch('adb_shell.auth.sign_pythonrsa.open', open_priv_pub), patch('adb_shell.auth.keygen.open', open_priv_pub):
+            keygen('tests/adbkey')
+            signer = PythonRSASigner.FromRSAKeyPath('tests/adbkey')
+            signer.pub_key = u''
+
+        self._callback_invoked = False
+        def auth_callback(device):
+            self._callback_invoked = True
+
+        self.device._handle._bulk_read = b''.join(patchers.BULK_READ_LIST_WITH_AUTH_NEW_KEY)
+
+        self.assertTrue(self.device.connect([signer], auth_callback=auth_callback))
+        self.assertTrue(self._callback_invoked)
+
+
     # ======================================================================= #
     #                                                                         #
     #                              `shell` tests                              #


### PR DESCRIPTION
 * This is invoked when we are waiting for auth to be
   accepted on the device. It can be used for displaying
   a message to the user which indicates manual action
   is required to complete the connection.