### PR TITLE
Sync packet size

### DIFF
--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -438,7 +438,7 @@ class AdbDevice(object):
             raise exceptions.AdbConnectionError("ADB command not sent because a connection to the device has not been established.  (Did you call `AdbDevice.connect()`?)")
 
         adb_info = _AdbTransactionInfo(None, None, transport_timeout_s, read_timeout_s)
-        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_LIST_FORMAT)
+        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_LIST_FORMAT, maxdata=self._maxdata)
         self._open(b'sync:', adb_info)
 
         self._filesync_send(constants.LIST, adb_info, filesync_info, data=device_path)
@@ -493,7 +493,7 @@ class AdbDevice(object):
             raise ValueError("dest_file is of unknown type")
 
         adb_info = _AdbTransactionInfo(None, None, transport_timeout_s, read_timeout_s)
-        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_PULL_FORMAT)
+        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_PULL_FORMAT, maxdata=self._maxdata)
 
         with _open(dest_file, 'wb') as dest:
             self._open(b'sync:', adb_info)
@@ -573,7 +573,7 @@ class AdbDevice(object):
                 return
 
         adb_info = _AdbTransactionInfo(None, None, transport_timeout_s, read_timeout_s)
-        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_PUSH_FORMAT)
+        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_PUSH_FORMAT, maxdata=self._maxdata)
 
         with _open(source_file, 'rb') as source:
             self._open(b'sync:', adb_info)
@@ -663,7 +663,7 @@ class AdbDevice(object):
         adb_info = _AdbTransactionInfo(None, None, transport_timeout_s, read_timeout_s)
         self._open(b'sync:', adb_info)
 
-        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_STAT_FORMAT)
+        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_STAT_FORMAT, maxdata=self._maxdata)
         self._filesync_send(constants.STAT, adb_info, filesync_info, data=device_filename)
         _, (mode, size, mtime), _ = self._filesync_read([constants.STAT], adb_info, filesync_info, read_data=False)
         self._close(adb_info)

--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -796,7 +796,7 @@ class AdbDevice(object):
             data = bytearray()
             while data_length > 0:
                 temp = self._transport.bulk_read(data_length, adb_info.transport_timeout_s)
-                _LOGGER.debug("bulk_read(%d): %s", data_length, repr(temp))
+                _LOGGER.debug("bulk_read(%d): %.1000s", data_length, repr(temp))
 
                 data += temp
                 data_length -= len(temp)

--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -107,6 +107,8 @@ class AdbDevice(object):
         The hostname of the machine where the Python interpreter is currently running
     _transport : BaseTransport
         The transport that is used to connect to the device; must be a subclass of :class:`~adb_shell.transport.base_transport.BaseTransport`
+    _maxdata: int
+        Maximum amount of data in an ADB packet.
 
     """
 

--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -105,10 +105,10 @@ class AdbDevice(object):
         Whether an ADB connection to the device has been established
     _banner : bytearray, bytes
         The hostname of the machine where the Python interpreter is currently running
+    _maxdata: int
+        Maximum amount of data in an ADB packet
     _transport : BaseTransport
         The transport that is used to connect to the device; must be a subclass of :class:`~adb_shell.transport.base_transport.BaseTransport`
-    _maxdata: int
-        Maximum amount of data in an ADB packet.
 
     """
 

--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -139,7 +139,7 @@ class AdbDevice(object):
         Returns
         -------
         int
-            minimum value based on :const:`adb_shell.constants.MAX_CHUNK_SIZE` and ``_max_data / 2``, fallback to legacy :const:`adb_shell.constants.MAX_PUSH_DATA`
+            Minimum value based on :const:`adb_shell.constants.MAX_CHUNK_SIZE` and ``_max_data / 2``, fallback to legacy :const:`adb_shell.constants.MAX_PUSH_DATA`
 
         """
         return min(constants.MAX_CHUNK_SIZE, self._maxdata // 2) or constants.MAX_PUSH_DATA

--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -131,6 +131,18 @@ class AdbDevice(object):
         self._maxdata = constants.MAX_PUSH_DATA
 
     @property
+    def max_chunk_size(self):
+        """ Maximum chunk size for filesync operations
+
+        Returns
+        -------
+        int
+            minimum value based on MAX_CHUNK_SIZE and _max_data / 2
+
+        """
+        return min(constants.MAX_CHUNK_SIZE, self._maxdata // 2)
+
+    @property
     def available(self):
         """Whether or not an ADB connection to the device has been established.
 
@@ -603,7 +615,7 @@ class AdbDevice(object):
             next(progress)
 
         while True:
-            data = datafile.read(self._maxdata)
+            data = datafile.read(self.max_chunk_size)
             if data:
                 self._filesync_send(constants.DATA, adb_info, filesync_info, data=data)
 

--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -137,10 +137,10 @@ class AdbDevice(object):
         Returns
         -------
         int
-            minimum value based on MAX_CHUNK_SIZE and _max_data / 2
+            minimum value based on MAX_CHUNK_SIZE and _max_data / 2, fallback to legacy MAX_PUSH_DATA
 
         """
-        return min(constants.MAX_CHUNK_SIZE, self._maxdata // 2)
+        return min(constants.MAX_CHUNK_SIZE, self._maxdata // 2) or constants.MAX_PUSH_DATA
 
     @property
     def available(self):

--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -134,12 +134,12 @@ class AdbDevice(object):
 
     @property
     def max_chunk_size(self):
-        """ Maximum chunk size for filesync operations
+        """Maximum chunk size for filesync operations
 
         Returns
         -------
         int
-            minimum value based on MAX_CHUNK_SIZE and _max_data / 2, fallback to legacy MAX_PUSH_DATA
+            minimum value based on :const:`adb_shell.constants.MAX_CHUNK_SIZE` and ``_max_data / 2``, fallback to legacy :const:`adb_shell.constants.MAX_PUSH_DATA`
 
         """
         return min(constants.MAX_CHUNK_SIZE, self._maxdata // 2) or constants.MAX_PUSH_DATA

--- a/adb_shell/adb_device_async.py
+++ b/adb_shell/adb_device_async.py
@@ -130,10 +130,10 @@ class AdbDeviceAsync(object):
         Returns
         -------
         int
-            minimum value based on MAX_CHUNK_SIZE and _max_data / 2
+            minimum value based on MAX_CHUNK_SIZE and _max_data / 2, fallback to legacy MAX_PUSH_DATA
 
         """
-        return min(constants.MAX_CHUNK_SIZE, self._maxdata // 2)
+        return min(constants.MAX_CHUNK_SIZE, self._maxdata // 2) or constants.MAX_PUSH_DATA
 
     @property
     def available(self):

--- a/adb_shell/adb_device_async.py
+++ b/adb_shell/adb_device_async.py
@@ -132,7 +132,7 @@ class AdbDeviceAsync(object):
         Returns
         -------
         int
-            minimum value based on :const:`adb_shell.constants.MAX_CHUNK_SIZE` and ``_max_data / 2``, fallback to legacy :const:`adb_shell.constants.MAX_PUSH_DATA`
+            Minimum value based on :const:`adb_shell.constants.MAX_CHUNK_SIZE` and ``_max_data / 2``, fallback to legacy :const:`adb_shell.constants.MAX_PUSH_DATA`
 
         """
         return min(constants.MAX_CHUNK_SIZE, self._maxdata // 2) or constants.MAX_PUSH_DATA

--- a/adb_shell/adb_device_async.py
+++ b/adb_shell/adb_device_async.py
@@ -97,10 +97,10 @@ class AdbDeviceAsync(object):
         Whether an ADB connection to the device has been established
     _banner : bytearray, bytes
         The hostname of the machine where the Python interpreter is currently running
-    _transport : BaseTransportAsync
-        The transport that is used to connect to the device; must be a subclass of :class:`~adb_shell.transport.base_transport_async.BaseTransportAsync`
     _maxdata: int
         Maximum amount of data in an ADB packet.
+    _transport : BaseTransportAsync
+        The transport that is used to connect to the device; must be a subclass of :class:`~adb_shell.transport.base_transport_async.BaseTransportAsync`
 
     """
 
@@ -127,12 +127,12 @@ class AdbDeviceAsync(object):
 
     @property
     def max_chunk_size(self):
-        """ Maximum chunk size for filesync operations
+        """Maximum chunk size for filesync operations
 
         Returns
         -------
         int
-            minimum value based on MAX_CHUNK_SIZE and _max_data / 2, fallback to legacy MAX_PUSH_DATA
+            minimum value based on :const:`adb_shell.constants.MAX_CHUNK_SIZE` and ``_max_data / 2``, fallback to legacy :const:`adb_shell.constants.MAX_PUSH_DATA`
 
         """
         return min(constants.MAX_CHUNK_SIZE, self._maxdata // 2) or constants.MAX_PUSH_DATA

--- a/adb_shell/adb_device_async.py
+++ b/adb_shell/adb_device_async.py
@@ -431,7 +431,7 @@ class AdbDeviceAsync(object):
             raise exceptions.AdbConnectionError("ADB command not sent because a connection to the device has not been established.  (Did you call `AdbDeviceAsync.connect()`?)")
 
         adb_info = _AdbTransactionInfo(None, None, transport_timeout_s, read_timeout_s)
-        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_LIST_FORMAT)
+        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_LIST_FORMAT, maxdata=self._maxdata)
         await self._open(b'sync:', adb_info)
 
         await self._filesync_send(constants.LIST, adb_info, filesync_info, data=device_path)
@@ -486,7 +486,7 @@ class AdbDeviceAsync(object):
             raise ValueError("dest_file is of unknown type")
 
         adb_info = _AdbTransactionInfo(None, None, transport_timeout_s, read_timeout_s)
-        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_PULL_FORMAT)
+        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_PULL_FORMAT, maxdata=self._maxdata)
 
         with _open(dest_file, 'wb') as dest:
             await self._open(b'sync:', adb_info)
@@ -566,7 +566,7 @@ class AdbDeviceAsync(object):
                 return
 
         adb_info = _AdbTransactionInfo(None, None, transport_timeout_s, read_timeout_s)
-        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_PUSH_FORMAT)
+        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_PUSH_FORMAT, maxdata=self._maxdata)
 
         with _open(source_file, 'rb') as source:
             await self._open(b'sync:', adb_info)
@@ -656,7 +656,7 @@ class AdbDeviceAsync(object):
         adb_info = _AdbTransactionInfo(None, None, transport_timeout_s, read_timeout_s)
         await self._open(b'sync:', adb_info)
 
-        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_STAT_FORMAT)
+        filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_STAT_FORMAT, maxdata=self._maxdata)
         await self._filesync_send(constants.STAT, adb_info, filesync_info, data=device_filename)
         _, (mode, size, mtime), _ = await self._filesync_read([constants.STAT], adb_info, filesync_info, read_data=False)
         await self._close(adb_info)

--- a/adb_shell/adb_device_async.py
+++ b/adb_shell/adb_device_async.py
@@ -789,7 +789,7 @@ class AdbDeviceAsync(object):
             data = bytearray()
             while data_length > 0:
                 temp = await self._transport.bulk_read(data_length, adb_info.transport_timeout_s)
-                _LOGGER.debug("bulk_read(%d): %s", data_length, repr(temp))
+                _LOGGER.debug("bulk_read(%d): %.1000s", data_length, repr(temp))
 
                 data += temp
                 data_length -= len(temp)

--- a/adb_shell/adb_device_async.py
+++ b/adb_shell/adb_device_async.py
@@ -124,6 +124,18 @@ class AdbDeviceAsync(object):
         self._maxdata = constants.MAX_PUSH_DATA
 
     @property
+    def max_chunk_size(self):
+        """ Maximum chunk size for filesync operations
+
+        Returns
+        -------
+        int
+            minimum value based on MAX_CHUNK_SIZE and _max_data / 2
+
+        """
+        return min(constants.MAX_CHUNK_SIZE, self._maxdata // 2)
+
+    @property
     def available(self):
         """Whether or not an ADB connection to the device has been established.
 
@@ -596,7 +608,7 @@ class AdbDeviceAsync(object):
             next(progress)
 
         while True:
-            data = datafile.read(self._maxdata)
+            data = datafile.read(self.max_chunk_size)
             if data:
                 await self._filesync_send(constants.DATA, adb_info, filesync_info, data=data)
 

--- a/adb_shell/adb_device_async.py
+++ b/adb_shell/adb_device_async.py
@@ -99,6 +99,8 @@ class AdbDeviceAsync(object):
         The hostname of the machine where the Python interpreter is currently running
     _transport : BaseTransportAsync
         The transport that is used to connect to the device; must be a subclass of :class:`~adb_shell.transport.base_transport_async.BaseTransportAsync`
+    _maxdata: int
+        Maximum amount of data in an ADB packet.
 
     """
 

--- a/adb_shell/adb_device_async.py
+++ b/adb_shell/adb_device_async.py
@@ -98,7 +98,7 @@ class AdbDeviceAsync(object):
     _banner : bytearray, bytes
         The hostname of the machine where the Python interpreter is currently running
     _maxdata: int
-        Maximum amount of data in an ADB packet.
+        Maximum amount of data in an ADB packet
     _transport : BaseTransportAsync
         The transport that is used to connect to the device; must be a subclass of :class:`~adb_shell.transport.base_transport_async.BaseTransportAsync`
 

--- a/adb_shell/constants.py
+++ b/adb_shell/constants.py
@@ -42,8 +42,11 @@ VERSION = 0x01000000
 #: Maximum amount of data in an ADB packet. According to: https://android.googlesource.com/platform/system/core/+/master/adb/adb.h
 MAX_ADB_DATA = 1024 * 1024
 
-#: Maximum size of a filesync DATA packet.
+#: Maximum size of a filesync DATA packet. Default size.
 MAX_PUSH_DATA = 2 * 1024
+
+#: Maximum chunk size. According to https://android.googlesource.com/platform/system/core/+/master/adb/SYNC.TXT
+MAX_CHUNK_SIZE = 64 * 1024
 
 #: Default mode for pushed files.
 DEFAULT_PUSH_MODE = stat.S_IFREG | stat.S_IRWXU | stat.S_IRWXG

--- a/adb_shell/constants.py
+++ b/adb_shell/constants.py
@@ -39,11 +39,11 @@ PROTOCOL = 0x01
 #: ADB protocol version.
 VERSION = 0x01000000
 
-#: Maximum amount of data in an ADB packet.
-MAX_ADB_DATA = 4096
+#: Maximum amount of data in an ADB packet. According to: https://android.googlesource.com/platform/system/core/+/master/adb/adb.h
+MAX_ADB_DATA = 1024 * 1024
 
 #: Maximum size of a filesync DATA packet.
-MAX_PUSH_DATA = 2048
+MAX_PUSH_DATA = 2 * 1024
 
 #: Default mode for pushed files.
 DEFAULT_PUSH_MODE = stat.S_IFREG | stat.S_IRWXU | stat.S_IRWXG

--- a/adb_shell/constants.py
+++ b/adb_shell/constants.py
@@ -41,6 +41,7 @@ VERSION = 0x01000000
 
 #: Maximum amount of data in an ADB packet. According to: https://android.googlesource.com/platform/system/core/+/master/adb/adb.h
 MAX_ADB_DATA = 1024 * 1024
+MAX_LEGACY_ADB_DATA = 4 * 1024
 
 #: Maximum size of a filesync DATA packet. Default size.
 MAX_PUSH_DATA = 2 * 1024

--- a/adb_shell/hidden_helpers.py
+++ b/adb_shell/hidden_helpers.py
@@ -153,13 +153,15 @@ class _FileSyncTransactionInfo(object):  # pylint: disable=too-few-public-method
         The index in ``recv_buffer`` that will be the start of the next data packet sent
 
     """
-    def __init__(self, recv_message_format):
-        self.send_buffer = bytearray(constants.MAX_ADB_DATA)
+    def __init__(self, recv_message_format, maxdata=constants.MAX_ADB_DATA):
+        self.send_buffer = bytearray(maxdata)
         self.send_idx = 0
 
         self.recv_buffer = bytearray()
         self.recv_message_format = recv_message_format
         self.recv_message_size = struct.calcsize(recv_message_format)
+
+        self._maxdata = maxdata
 
     def can_add_to_send_buffer(self, data_len):
         """Determine whether ``data_len`` bytes of data can be added to the send buffer without exceeding :const:`constants.MAX_ADB_DATA`.
@@ -176,4 +178,4 @@ class _FileSyncTransactionInfo(object):  # pylint: disable=too-few-public-method
 
         """
         added_len = self.recv_message_size + data_len
-        return self.send_idx + added_len < constants.MAX_ADB_DATA
+        return self.send_idx + added_len < self._maxdata

--- a/adb_shell/hidden_helpers.py
+++ b/adb_shell/hidden_helpers.py
@@ -139,10 +139,12 @@ class _FileSyncTransactionInfo(object):  # pylint: disable=too-few-public-method
     recv_message_format : bytes
         The FileSync message format
     maxdata: int
-        Maximum amount of data in an ADB packet.
+        Maximum amount of data in an ADB packet
 
     Attributes
     ----------
+    _maxdata: int
+        Maximum amount of data in an ADB packet
     recv_buffer : bytearray
         A buffer for storing received data
     recv_message_format : bytes
@@ -153,8 +155,6 @@ class _FileSyncTransactionInfo(object):  # pylint: disable=too-few-public-method
         A buffer for storing data to be sent
     send_idx : int
         The index in ``recv_buffer`` that will be the start of the next data packet sent
-    _maxdata: int
-        Maximum amount of data in an ADB packet.
 
     """
     def __init__(self, recv_message_format, maxdata=constants.MAX_ADB_DATA):

--- a/adb_shell/hidden_helpers.py
+++ b/adb_shell/hidden_helpers.py
@@ -138,6 +138,8 @@ class _FileSyncTransactionInfo(object):  # pylint: disable=too-few-public-method
     ----------
     recv_message_format : bytes
         The FileSync message format
+    maxdata: int
+        Maximum amount of data in an ADB packet.
 
     Attributes
     ----------
@@ -151,6 +153,8 @@ class _FileSyncTransactionInfo(object):  # pylint: disable=too-few-public-method
         A buffer for storing data to be sent
     send_idx : int
         The index in ``recv_buffer`` that will be the start of the next data packet sent
+    _maxdata: int
+        Maximum amount of data in an ADB packet.
 
     """
     def __init__(self, recv_message_format, maxdata=constants.MAX_ADB_DATA):

--- a/tests/patchers.py
+++ b/tests/patchers.py
@@ -12,9 +12,9 @@ ASYNC_SKIPPER=unittest.skipIf(sys.version_info.major < 3 or sys.version_info.min
 MSG_CONNECT = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=constants.MAX_LEGACY_ADB_DATA, data=b'host::unknown\0')
 MSG_CONNECT_WITH_AUTH_INVALID = AdbMessage(command=constants.AUTH, arg0=0, arg1=0, data=b'host::unknown\0')
 MSG_CONNECT_WITH_AUTH1 = AdbMessage(command=constants.AUTH, arg0=constants.AUTH_TOKEN, arg1=0, data=b'host::unknown\0')
-MSG_CONNECT_WITH_AUTH2 = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=constants.MAX_ADB_DATA, data=b'host::unknown\0')
+MSG_CONNECT_WITH_AUTH2 = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=2*constants.MAX_LEGACY_ADB_DATA, data=b'host::unknown\0')
 MSG_CONNECT_WITH_AUTH_NEW_KEY2 = AdbMessage(command=constants.AUTH, arg0=0, arg1=0, data=b'host::unknown\0')
-MSG_CONNECT_WITH_AUTH_NEW_KEY3 = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=constants.MAX_ADB_DATA, data=b'host::unknown\0')
+MSG_CONNECT_WITH_AUTH_NEW_KEY3 = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=3*constants.MAX_LEGACY_ADB_DATA, data=b'host::unknown\0')
 
 BULK_READ_LIST = [MSG_CONNECT.pack(), MSG_CONNECT.data]
 BULK_READ_LIST_WITH_AUTH_INVALID = [MSG_CONNECT_WITH_AUTH_INVALID.pack(), MSG_CONNECT_WITH_AUTH_INVALID.data]

--- a/tests/patchers.py
+++ b/tests/patchers.py
@@ -9,12 +9,12 @@ from adb_shell.transport.tcp_transport import TcpTransport
 
 ASYNC_SKIPPER=unittest.skipIf(sys.version_info.major < 3 or sys.version_info.minor < 6, "Async functionality requires Python 3.6+")
 
-MSG_CONNECT = AdbMessage(command=constants.CNXN, arg0=0, arg1=0, data=b'host::unknown\0')
+MSG_CONNECT = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=constants.MAX_LEGACY_ADB_DATA, data=b'host::unknown\0')
 MSG_CONNECT_WITH_AUTH_INVALID = AdbMessage(command=constants.AUTH, arg0=0, arg1=0, data=b'host::unknown\0')
 MSG_CONNECT_WITH_AUTH1 = AdbMessage(command=constants.AUTH, arg0=constants.AUTH_TOKEN, arg1=0, data=b'host::unknown\0')
-MSG_CONNECT_WITH_AUTH2 = AdbMessage(command=constants.CNXN, arg0=0, arg1=0, data=b'host::unknown\0')
+MSG_CONNECT_WITH_AUTH2 = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=constants.MAX_ADB_DATA, data=b'host::unknown\0')
 MSG_CONNECT_WITH_AUTH_NEW_KEY2 = AdbMessage(command=constants.AUTH, arg0=0, arg1=0, data=b'host::unknown\0')
-MSG_CONNECT_WITH_AUTH_NEW_KEY3 = AdbMessage(command=constants.CNXN, arg0=0, arg1=0, data=b'host::unknown\0')
+MSG_CONNECT_WITH_AUTH_NEW_KEY3 = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=constants.MAX_ADB_DATA, data=b'host::unknown\0')
 
 BULK_READ_LIST = [MSG_CONNECT.pack(), MSG_CONNECT.data]
 BULK_READ_LIST_WITH_AUTH_INVALID = [MSG_CONNECT_WITH_AUTH_INVALID.pack(), MSG_CONNECT_WITH_AUTH_INVALID.data]

--- a/tests/test_adb_device.py
+++ b/tests/test_adb_device.py
@@ -225,7 +225,7 @@ class TestAdbDevice(unittest.TestCase):
 
         # Provide the `bulk_read` return values
         self.device._transport._bulk_read = join_messages(AdbMessage(command=constants.OKAY, arg0=1, arg1=1, data=b'\x00'),
-                                                          AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=b'0'*(constants.MAX_ADB_DATA+1)),
+                                                          AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=b'0'*(self.device.max_chunk_size+1)),
                                                           AdbMessage(command=constants.CLSE, arg0=1, arg1=1, data=b''))
 
         self.device.shell('TEST')
@@ -236,10 +236,10 @@ class TestAdbDevice(unittest.TestCase):
 
         # Provide the `bulk_read` return values
         self.device._transport._bulk_read = join_messages(AdbMessage(command=constants.OKAY, arg0=1, arg1=1, data=b'\x00'),
-                                                          AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=b'0'*(constants.MAX_ADB_DATA-1) + b'\xe3\x81\x82'),
+                                                          AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=b'0'*(self.device.max_chunk_size-1) + b'\xe3\x81\x82'),
                                                           AdbMessage(command=constants.CLSE, arg0=1, arg1=1, data=b''))
 
-        self.assertEqual(u'0'*(constants.MAX_ADB_DATA-1) + u'\u3042', self.device.shell('TEST'))
+        self.assertEqual(u'0'*(self.device.max_chunk_size-1) + u'\u3042', self.device.shell('TEST'))
 
     def test_shell_with_multibytes_sequence_over_two_messages(self):
         self.assertTrue(self.device.connect())

--- a/tests/test_adb_device.py
+++ b/tests/test_adb_device.py
@@ -605,16 +605,16 @@ class TestAdbDevice(unittest.TestCase):
                                                           AdbMessage(command=constants.CLSE, arg0=1, arg1=1, data=b''))
 
         # Expected `bulk_write` values
-        mpd0, mpd1, mpd2, mpd3 = 0, self.device.max_chunk_size, 2*self.device.max_chunk_size, 3*self.device.max_chunk_size
+        mcs0, mcs1, mcs2, mcs3 = 0, self.device.max_chunk_size, 2*self.device.max_chunk_size, 3*self.device.max_chunk_size
         expected_bulk_write = join_messages(AdbMessage(command=constants.OPEN, arg0=1, arg1=0, data=b'sync:\x00'),
                                             AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(
                                                 FileSyncMessage(command=constants.SEND, data=b'/data,33272'),
-                                                FileSyncMessage(command=constants.DATA, data=filedata[mpd0:mpd1]))),
+                                                FileSyncMessage(command=constants.DATA, data=filedata[mcs0:mcs1]))),
                                             AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(
-                                                FileSyncMessage(command=constants.DATA, data=filedata[mpd1:mpd2]))),
+                                                FileSyncMessage(command=constants.DATA, data=filedata[mcs1:mcs2]))),
                                             AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(
-                                                FileSyncMessage(command=constants.DATA, data=filedata[mpd2:mpd3]),
-                                                FileSyncMessage(command=constants.DATA, data=filedata[mpd3:]),
+                                                FileSyncMessage(command=constants.DATA, data=filedata[mcs2:mcs3]),
+                                                FileSyncMessage(command=constants.DATA, data=filedata[mcs3:]),
                                                 FileSyncMessage(command=constants.DONE, arg0=mtime))),
                                             AdbMessage(command=constants.OKAY, arg0=1, arg1=1),
                                             AdbMessage(command=constants.CLSE, arg0=1, arg1=1, data=b''))

--- a/tests/test_adb_device.py
+++ b/tests/test_adb_device.py
@@ -715,7 +715,7 @@ class TestAdbDevice(unittest.TestCase):
         self.assertTrue(self.device.connect())
         self.device._transport._bulk_write = b''
 
-        filedata = b'0' * int(1.5 * constants.MAX_ADB_DATA)
+        filedata = b'0' * int(1.5 * self.device.max_chunk_size)
 
         # Provide the `bulk_read` return values
 

--- a/tests/test_adb_device.py
+++ b/tests/test_adb_device.py
@@ -594,7 +594,7 @@ class TestAdbDevice(unittest.TestCase):
         self.device._transport._bulk_write = b''
 
         mtime = 100
-        filedata = b'0' * int(3.5 * constants.MAX_PUSH_DATA)
+        filedata = b'0' * int(3.5 * self.device.max_chunk_size)
 
         # Provide the `bulk_read` return values
         self.device._transport._bulk_read = join_messages(AdbMessage(command=constants.OKAY, arg0=1, arg1=1, data=b'\x00'),
@@ -605,12 +605,12 @@ class TestAdbDevice(unittest.TestCase):
                                                           AdbMessage(command=constants.CLSE, arg0=1, arg1=1, data=b''))
 
         # Expected `bulk_write` values
-        mpd0, mpd1, mpd2, mpd3 = 0, constants.MAX_PUSH_DATA, 2*constants.MAX_PUSH_DATA, 3*constants.MAX_PUSH_DATA
+        mpd0, mpd1, mpd2, mpd3 = 0, self.device.max_chunk_size, 2*self.device.max_chunk_size, 3*self.device.max_chunk_size
         expected_bulk_write = join_messages(AdbMessage(command=constants.OPEN, arg0=1, arg1=0, data=b'sync:\x00'),
                                             AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(FileSyncMessage(command=constants.SEND, data=b'/data,33272'),
-                                                                                                                  FileSyncMessage(command=constants.DATA, data=filedata[mpd0:mpd1]))),
-                                            AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(FileSyncMessage(command=constants.DATA, data=filedata[mpd1:mpd2]))),
-                                            AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(FileSyncMessage(command=constants.DATA, data=filedata[mpd2:mpd3]),
+                                                                                                                  FileSyncMessage(command=constants.DATA, data=filedata[mpd0:mpd1]),
+                                                                                                                  FileSyncMessage(command=constants.DATA, data=filedata[mpd1:mpd2]),
+                                                                                                                  FileSyncMessage(command=constants.DATA, data=filedata[mpd2:mpd3]),
                                                                                                                   FileSyncMessage(command=constants.DATA, data=filedata[mpd3:]),
                                                                                                                   FileSyncMessage(command=constants.DONE, arg0=mtime))),
                                             AdbMessage(command=constants.OKAY, arg0=1, arg1=1),

--- a/tests/test_adb_device_async.py
+++ b/tests/test_adb_device_async.py
@@ -635,7 +635,7 @@ class TestAdbDeviceAsync(unittest.TestCase):
         self.device._transport._bulk_write = b''
 
         mtime = 100
-        filedata = b'0' * int(3.5 * constants.MAX_PUSH_DATA)
+        filedata = b'0' * int(3.5 * self.device.max_chunk_size)
 
         # Provide the `bulk_read` return values
         self.device._transport._bulk_read = join_messages(AdbMessage(command=constants.OKAY, arg0=1, arg1=1, data=b'\x00'),
@@ -646,12 +646,12 @@ class TestAdbDeviceAsync(unittest.TestCase):
                                                           AdbMessage(command=constants.CLSE, arg0=1, arg1=1, data=b''))
 
         # Expected `bulk_write` values
-        mpd0, mpd1, mpd2, mpd3 = 0, constants.MAX_PUSH_DATA, 2*constants.MAX_PUSH_DATA, 3*constants.MAX_PUSH_DATA
+        mpd0, mpd1, mpd2, mpd3 = 0, self.device.max_chunk_size, 2*self.device.max_chunk_size, 3*self.device.max_chunk_size
         expected_bulk_write = join_messages(AdbMessage(command=constants.OPEN, arg0=1, arg1=0, data=b'sync:\x00'),
                                             AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(FileSyncMessage(command=constants.SEND, data=b'/data,33272'),
-                                                                                                                  FileSyncMessage(command=constants.DATA, data=filedata[mpd0:mpd1]))),
-                                            AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(FileSyncMessage(command=constants.DATA, data=filedata[mpd1:mpd2]))),
-                                            AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(FileSyncMessage(command=constants.DATA, data=filedata[mpd2:mpd3]),
+                                                                                                                  FileSyncMessage(command=constants.DATA, data=filedata[mpd0:mpd1]),
+                                                                                                                  FileSyncMessage(command=constants.DATA, data=filedata[mpd1:mpd2]),
+                                                                                                                  FileSyncMessage(command=constants.DATA, data=filedata[mpd2:mpd3]),
                                                                                                                   FileSyncMessage(command=constants.DATA, data=filedata[mpd3:]),
                                                                                                                   FileSyncMessage(command=constants.DONE, arg0=mtime))),
                                             AdbMessage(command=constants.OKAY, arg0=1, arg1=1),

--- a/tests/test_adb_device_async.py
+++ b/tests/test_adb_device_async.py
@@ -648,12 +648,15 @@ class TestAdbDeviceAsync(unittest.TestCase):
         # Expected `bulk_write` values
         mpd0, mpd1, mpd2, mpd3 = 0, self.device.max_chunk_size, 2*self.device.max_chunk_size, 3*self.device.max_chunk_size
         expected_bulk_write = join_messages(AdbMessage(command=constants.OPEN, arg0=1, arg1=0, data=b'sync:\x00'),
-                                            AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(FileSyncMessage(command=constants.SEND, data=b'/data,33272'),
-                                                                                                                  FileSyncMessage(command=constants.DATA, data=filedata[mpd0:mpd1]),
-                                                                                                                  FileSyncMessage(command=constants.DATA, data=filedata[mpd1:mpd2]),
-                                                                                                                  FileSyncMessage(command=constants.DATA, data=filedata[mpd2:mpd3]),
-                                                                                                                  FileSyncMessage(command=constants.DATA, data=filedata[mpd3:]),
-                                                                                                                  FileSyncMessage(command=constants.DONE, arg0=mtime))),
+                                            AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(
+                                                FileSyncMessage(command=constants.SEND, data=b'/data,33272'),
+                                                FileSyncMessage(command=constants.DATA, data=filedata[mpd0:mpd1]))),
+                                            AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(
+                                                FileSyncMessage(command=constants.DATA, data=filedata[mpd1:mpd2]))),
+                                            AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(
+                                                FileSyncMessage(command=constants.DATA, data=filedata[mpd2:mpd3]),
+                                                FileSyncMessage(command=constants.DATA, data=filedata[mpd3:]),
+                                                FileSyncMessage(command=constants.DONE, arg0=mtime))),
                                             AdbMessage(command=constants.OKAY, arg0=1, arg1=1),
                                             AdbMessage(command=constants.CLSE, arg0=1, arg1=1, data=b''))
 
@@ -761,7 +764,7 @@ class TestAdbDeviceAsync(unittest.TestCase):
         self.assertTrue(await self.device.connect())
         self.device._transport._bulk_write = b''
 
-        filedata = b'0' * int(1.5 * self.device.max_chunk_size)
+        filedata = b'0' * int(1.5 * constants.MAX_ADB_DATA)
 
         # Provide the `bulk_read` return values
 

--- a/tests/test_adb_device_async.py
+++ b/tests/test_adb_device_async.py
@@ -646,16 +646,16 @@ class TestAdbDeviceAsync(unittest.TestCase):
                                                           AdbMessage(command=constants.CLSE, arg0=1, arg1=1, data=b''))
 
         # Expected `bulk_write` values
-        mpd0, mpd1, mpd2, mpd3 = 0, self.device.max_chunk_size, 2*self.device.max_chunk_size, 3*self.device.max_chunk_size
+        mcs0, mcs1, mcs2, mcs3 = 0, self.device.max_chunk_size, 2*self.device.max_chunk_size, 3*self.device.max_chunk_size
         expected_bulk_write = join_messages(AdbMessage(command=constants.OPEN, arg0=1, arg1=0, data=b'sync:\x00'),
                                             AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(
                                                 FileSyncMessage(command=constants.SEND, data=b'/data,33272'),
-                                                FileSyncMessage(command=constants.DATA, data=filedata[mpd0:mpd1]))),
+                                                FileSyncMessage(command=constants.DATA, data=filedata[mcs0:mcs1]))),
                                             AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(
-                                                FileSyncMessage(command=constants.DATA, data=filedata[mpd1:mpd2]))),
+                                                FileSyncMessage(command=constants.DATA, data=filedata[mcs1:mcs2]))),
                                             AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=join_messages(
-                                                FileSyncMessage(command=constants.DATA, data=filedata[mpd2:mpd3]),
-                                                FileSyncMessage(command=constants.DATA, data=filedata[mpd3:]),
+                                                FileSyncMessage(command=constants.DATA, data=filedata[mcs2:mcs3]),
+                                                FileSyncMessage(command=constants.DATA, data=filedata[mcs3:]),
                                                 FileSyncMessage(command=constants.DONE, arg0=mtime))),
                                             AdbMessage(command=constants.OKAY, arg0=1, arg1=1),
                                             AdbMessage(command=constants.CLSE, arg0=1, arg1=1, data=b''))

--- a/tests/test_adb_device_async.py
+++ b/tests/test_adb_device_async.py
@@ -244,7 +244,7 @@ class TestAdbDeviceAsync(unittest.TestCase):
 
         # Provide the `bulk_read` return values
         self.device._transport._bulk_read = join_messages(AdbMessage(command=constants.OKAY, arg0=1, arg1=1, data=b'\x00'),
-                                                          AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=b'0'*(constants.MAX_ADB_DATA+1)),
+                                                          AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=b'0'*(self.device.max_chunk_size+1)),
                                                           AdbMessage(command=constants.CLSE, arg0=1, arg1=1, data=b''))
 
         await self.device.shell('TEST')
@@ -256,10 +256,10 @@ class TestAdbDeviceAsync(unittest.TestCase):
 
         # Provide the `bulk_read` return values
         self.device._transport._bulk_read = join_messages(AdbMessage(command=constants.OKAY, arg0=1, arg1=1, data=b'\x00'),
-                                                          AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=b'0'*(constants.MAX_ADB_DATA-1) + b'\xe3\x81\x82'),
+                                                          AdbMessage(command=constants.WRTE, arg0=1, arg1=1, data=b'0'*(self.device.max_chunk_size-1) + b'\xe3\x81\x82'),
                                                           AdbMessage(command=constants.CLSE, arg0=1, arg1=1, data=b''))
 
-        self.assertEqual(await self.device.shell('TEST'), u'0'*(constants.MAX_ADB_DATA-1) + u'\u3042')
+        self.assertEqual(await self.device.shell('TEST'), u'0'*(self.device.max_chunk_size-1) + u'\u3042')
 
     @awaiter
     async def test_shell_with_multibytes_sequence_over_two_messages(self):
@@ -761,7 +761,7 @@ class TestAdbDeviceAsync(unittest.TestCase):
         self.assertTrue(await self.device.connect())
         self.device._transport._bulk_write = b''
 
-        filedata = b'0' * int(1.5 * constants.MAX_ADB_DATA)
+        filedata = b'0' * int(1.5 * self.device.max_chunk_size)
 
         # Provide the `bulk_read` return values
 


### PR DESCRIPTION
Increase filesync packet size based on connection info. 

File transfer speed increased upto 10x.

Tested on samsung S5e tablet, with AdbTcpIp speed increased from ~500kB/s to ~5MB/s