### PR TITLE
Fix handling of missing libusb-1.0 lib by handling OSError too.

### DIFF
--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -76,7 +76,7 @@ from .hidden_helpers import FILE_TYPES, DeviceFile, _AdbTransactionInfo, _FileSy
 
 try:
     from .transport.usb_transport import UsbTransport
-except ImportError:
+except (ImportError, OSError):
     UsbTransport = None
 
 


### PR DESCRIPTION
Missing libusb-1.0 library causes OSError on windows.