### PR TITLE
Require Python 3.7+ for async functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ install:
   - pip install .
   - pip install flake8 pylint coveralls cryptography libusb1>=1.0.16 pycryptodome
   - python --version 2>&1 | grep -q "Python 2" && pip install mock || true
-  - if python --version 2>&1 | grep -q "Python 3.6" || python --version 2>&1 | grep -q "Python 3.7" || python --version 2>&1 | grep -q "Python 3.8"; then pip install aiofiles; fi
+  - if python --version 2>&1 | grep -q "Python 3.7" || python --version 2>&1 | grep -q "Python 3.8"; then pip install aiofiles; fi
 script:
-  - if python --version 2>&1 | grep -q "Python 2" || python --version 2>&1 | grep -q "Python 3.5"; then flake8 adb_shell/ --exclude="adb_shell/adb_device_async.py,adb_shell/transport/base_transport_async.py,adb_shell/transport/tcp_transport_async.py" && pylint --ignore="adb_device_async.py,base_transport_async.py,tcp_transport_async.py" adb_shell/; fi
-  - if python --version 2>&1 | grep -q "Python 3.6" || python --version 2>&1 | grep -q "Python 3.7" || python --version 2>&1 | grep -q "Python 3.8"; then flake8 adb_shell/ && pylint adb_shell/; fi
-  - if python --version 2>&1 | grep -q "Python 2" || python --version 2>&1 | grep -q "Python 3.5"; then for synctest in $(cd tests && ls test*.py | grep -v async); do python -m unittest discover -s tests/ -t . -p "$synctest" || exit 1; done; fi
-  - if python --version 2>&1 | grep -q "Python 3.6" || python --version 2>&1 | grep -q "Python 3.7" || python --version 2>&1 | grep -q "Python 3.8"; then coverage run --source adb_shell -m unittest discover -s tests/ -t . && coverage report -m; fi
+  - if python --version 2>&1 | grep -q "Python 2" || python --version 2>&1 | grep -q "Python 3.5" || python --version 2>&1 | grep -q "Python 3.6"; then flake8 adb_shell/ --exclude="adb_shell/adb_device_async.py,adb_shell/transport/base_transport_async.py,adb_shell/transport/tcp_transport_async.py" && pylint --ignore="adb_device_async.py,base_transport_async.py,tcp_transport_async.py" adb_shell/; fi
+  - if python --version 2>&1 | grep -q "Python 3.7" || python --version 2>&1 | grep -q "Python 3.8"; then flake8 adb_shell/ && pylint adb_shell/; fi
+  - if python --version 2>&1 | grep -q "Python 2" || python --version 2>&1 | grep -q "Python 3.5" || python --version 2>&1 | grep -q "Python 3.6"; then for synctest in $(cd tests && ls test*.py | grep -v async); do python -m unittest discover -s tests/ -t . -p "$synctest" || exit 1; done; fi
+  - if python --version 2>&1 | grep -q "Python 3.7" || python --version 2>&1 | grep -q "Python 3.8"; then coverage run --source adb_shell -m unittest discover -s tests/ -t . && coverage report -m; fi
 after_success:
   - if python --version 2>&1 | grep -q "Python 3.7" || python --version 2>&1 | grep -q "Python 3.8"; then coveralls; fi

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Installation
 Async
 *****
 
-To utilize the async version of this code, you must install into a Python 3.6+ environment via:
+To utilize the async version of this code, you must install into a Python 3.7+ environment via:
 
 .. code-block::
 

--- a/adb_shell/adb_device_async.py
+++ b/adb_shell/adb_device_async.py
@@ -57,11 +57,7 @@
 """
 
 
-try:
-    from asyncio import get_running_loop
-except ImportError:  # pragma: no cover
-    from asyncio import get_event_loop as get_running_loop  # Python 3.6 compatibility
-
+from asyncio import get_running_loop
 import logging
 import os
 import socket

--- a/tests/patchers.py
+++ b/tests/patchers.py
@@ -8,8 +8,7 @@ from adb_shell.adb_message import AdbMessage
 from adb_shell.transport.tcp_transport import TcpTransport
 
 
-ASYNC_SKIPPER=unittest.skipIf(sys.version_info.major < 3 or sys.version_info.minor < 6, "Async functionality requires Python 3.6+")
-ASYNC_SKIPPER37=unittest.skipIf(sys.version_info.major < 3 or sys.version_info.minor < 7, "Async functionality requires Python 3.6+")
+ASYNC_SKIPPER=unittest.skipIf(sys.version_info.major < 3 or sys.version_info.minor < 7, "Async functionality requires Python 3.7+")
 
 MSG_CONNECT = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=constants.MAX_LEGACY_ADB_DATA, data=b'host::unknown\0')
 MSG_CONNECT_WITH_AUTH_INVALID = AdbMessage(command=constants.AUTH, arg0=0, arg1=0, data=b'host::unknown\0')

--- a/tests/test_adb_device_async.py
+++ b/tests/test_adb_device_async.py
@@ -553,7 +553,7 @@ class TestAdbDeviceAsync(unittest.TestCase):
         self.assertEqual(await self.device.list('/dir'), expected_result)
         self.assertEqual(self.device._transport._bulk_write, expected_bulk_write)
 
-    @patchers.ASYNC_SKIPPER37
+    @patchers.ASYNC_SKIPPER
     @awaiter
     async def test_push_fail(self):
         self.assertTrue(await self.device.connect())
@@ -570,7 +570,7 @@ class TestAdbDeviceAsync(unittest.TestCase):
         with self.assertRaises(exceptions.PushFailedError), patch('aiofiles.open', async_mock_open(read_data=filedata)):
             await self.device.push('TEST_FILE', '/data', mtime=mtime)
 
-    @patchers.ASYNC_SKIPPER37
+    @patchers.ASYNC_SKIPPER
     @awaiter
     async def test_push_file(self):
         self.assertTrue(await self.device.connect())
@@ -597,7 +597,7 @@ class TestAdbDeviceAsync(unittest.TestCase):
             await self.device.push('TEST_FILE', '/data', mtime=mtime)
             self.assertEqual(self.device._transport._bulk_write, expected_bulk_write)
 
-    @patchers.ASYNC_SKIPPER37
+    @patchers.ASYNC_SKIPPER
     @awaiter
     async def test_push_file_mtime0(self):
         self.assertTrue(await self.device.connect())
@@ -624,7 +624,7 @@ class TestAdbDeviceAsync(unittest.TestCase):
             await self.device.push('TEST_FILE', '/data', mtime=mtime)
             self.assertEqual(self.device._transport._bulk_write, expected_bulk_write)
 
-    @patchers.ASYNC_SKIPPER37
+    @patchers.ASYNC_SKIPPER
     @awaiter
     async def test_push_big_file(self):
         self.assertTrue(await self.device.connect())
@@ -660,7 +660,7 @@ class TestAdbDeviceAsync(unittest.TestCase):
             await self.device.push('TEST_FILE', '/data', mtime=mtime)
             self.assertEqual(self.device._transport._bulk_write, expected_bulk_write)
 
-    @patchers.ASYNC_SKIPPER37
+    @patchers.ASYNC_SKIPPER
     @awaiter
     async def test_push_dir(self):
         self.assertTrue(await self.device.connect())
@@ -686,7 +686,7 @@ class TestAdbDeviceAsync(unittest.TestCase):
         with patch('aiofiles.open', async_mock_open(read_data=filedata)), patch('os.path.isdir', lambda x: x == 'TEST_DIR/'), patch('os.listdir', return_value=['TEST_FILE1', 'TEST_FILE2']):
             await self.device.push('TEST_DIR/', '/data', mtime=mtime)
 
-    @patchers.ASYNC_SKIPPER37
+    @patchers.ASYNC_SKIPPER
     @awaiter
     async def test_pull_file(self):
         self.assertTrue(await self.device.connect())
@@ -712,7 +712,7 @@ class TestAdbDeviceAsync(unittest.TestCase):
             self.assertEqual(m.written, filedata)
             self.assertEqual(self.device._transport._bulk_write, expected_bulk_write)
 
-    @patchers.ASYNC_SKIPPER37
+    @patchers.ASYNC_SKIPPER
     @awaiter
     async def test_pull_big_file(self):
         self.assertTrue(await self.device.connect())


### PR DESCRIPTION
The `wait_closed()` used in the async TCP transport was introduced in Python 3.7. 