### PR TITLE
fix: Encode data for filesync reliably

### DIFF
--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -1082,7 +1082,7 @@ class AdbDevice(object):
             if cmd_id in finish_ids:  # pragma: no cover
                 break
 
-    def _filesync_send(self, command_id, adb_info, filesync_info, data=b'', size=0):
+    def _filesync_send(self, command_id, adb_info, filesync_info, data=b'', size=None):
         """Send/buffer FileSync packets.
 
         Packets are buffered and only flushed when this connection is read from. All
@@ -1102,9 +1102,9 @@ class AdbDevice(object):
             Optionally override size from len(data).
 
         """
-        if data:
-            if not isinstance(data, bytes):
-                data = data.encode('utf8')
+        if not isinstance(data, bytes):
+            data = data.encode('utf8')
+        if size is None:
             size = len(data)
 
         if not filesync_info.can_add_to_send_buffer(len(data)):

--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -1106,7 +1106,7 @@ class AdbDevice(object):
             Data and storage for this FileSync transaction
         data : str, bytes
             Optional data to send, must set data or size.
-        size : int
+        size : int, None
             Optionally override size from len(data).
 
         """

--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -433,6 +433,8 @@ class AdbDevice(object):
             Filename, mode, size, and mtime info for the files in the directory
 
         """
+        if not device_path:
+            raise exceptions.DevicePathInvalidError("Cannot list an empty device path")
         if not self.available:
             raise exceptions.AdbConnectionError("ADB command not sent because a connection to the device has not been established.  (Did you call `AdbDevice.connect()`?)")
 
@@ -471,6 +473,8 @@ class AdbDevice(object):
             The total time in seconds to wait for a ``b'CLSE'`` or ``b'OKAY'`` command in :meth:`AdbDevice._read`
 
         """
+        if not device_path:
+            raise exceptions.DevicePathInvalidError("Cannot pull from an empty device path")
         if not self.available:
             raise exceptions.AdbConnectionError("ADB command not sent because a connection to the device has not been established.  (Did you call `AdbDevice.connect()`?)")
 
@@ -534,6 +538,8 @@ class AdbDevice(object):
             The total time in seconds to wait for a ``b'CLSE'`` or ``b'OKAY'`` command in :meth:`AdbDevice._read`
 
         """
+        if not device_path:
+            raise exceptions.DevicePathInvalidError("Cannot push to an empty device path")
         if not self.available:
             raise exceptions.AdbConnectionError("ADB command not sent because a connection to the device has not been established.  (Did you call `AdbDevice.connect()`?)")
 
@@ -628,6 +634,8 @@ class AdbDevice(object):
             The last modified time for the file
 
         """
+        if not device_path:
+            raise exceptions.DevicePathInvalidError("Cannot stat an empty device path")
         if not self.available:
             raise exceptions.AdbConnectionError("ADB command not sent because a connection to the device has not been established.  (Did you call `AdbDevice.connect()`?)")
 

--- a/adb_shell/adb_device_async.py
+++ b/adb_shell/adb_device_async.py
@@ -1101,7 +1101,7 @@ class AdbDeviceAsync(object):
             Data and storage for this FileSync transaction
         data : str, bytes
             Optional data to send, must set data or size.
-        size : int
+        size : int, None
             Optionally override size from len(data).
 
         """

--- a/adb_shell/adb_device_async.py
+++ b/adb_shell/adb_device_async.py
@@ -428,6 +428,8 @@ class AdbDeviceAsync(object):
             Filename, mode, size, and mtime info for the files in the directory
 
         """
+        if not device_path:
+            raise exceptions.DevicePathInvalidError("Cannot list an empty device path")
         if not self.available:
             raise exceptions.AdbConnectionError("ADB command not sent because a connection to the device has not been established.  (Did you call `AdbDeviceAsync.connect()`?)")
 
@@ -466,6 +468,8 @@ class AdbDeviceAsync(object):
             The total time in seconds to wait for a ``b'CLSE'`` or ``b'OKAY'`` command in :meth:`AdbDevice._read`
 
         """
+        if not device_path:
+            raise exceptions.DevicePathInvalidError("Cannot pull from an empty device path")
         if not self.available:
             raise exceptions.AdbConnectionError("ADB command not sent because a connection to the device has not been established.  (Did you call `AdbDeviceAsync.connect()`?)")
 
@@ -529,6 +533,8 @@ class AdbDeviceAsync(object):
             The total time in seconds to wait for a ``b'CLSE'`` or ``b'OKAY'`` command in :meth:`AdbDeviceAsync._read`
 
         """
+        if not device_path:
+            raise exceptions.DevicePathInvalidError("Cannot push to an empty device path")
         if not self.available:
             raise exceptions.AdbConnectionError("ADB command not sent because a connection to the device has not been established.  (Did you call `AdbDeviceAsync.connect()`?)")
 
@@ -623,6 +629,8 @@ class AdbDeviceAsync(object):
             The last modified time for the file
 
         """
+        if not device_path:
+            raise exceptions.DevicePathInvalidError("Cannot stat an empty device path")
         if not self.available:
             raise exceptions.AdbConnectionError("ADB command not sent because a connection to the device has not been established.  (Did you call `AdbDeviceAsync.connect()`?)")
 

--- a/adb_shell/adb_device_async.py
+++ b/adb_shell/adb_device_async.py
@@ -1077,7 +1077,7 @@ class AdbDeviceAsync(object):
             if cmd_id in finish_ids:  # pragma: no cover
                 break
 
-    async def _filesync_send(self, command_id, adb_info, filesync_info, data=b'', size=0):
+    async def _filesync_send(self, command_id, adb_info, filesync_info, data=b'', size=None):
         """Send/buffer FileSync packets.
 
         Packets are buffered and only flushed when this connection is read from. All
@@ -1097,9 +1097,9 @@ class AdbDeviceAsync(object):
             Optionally override size from len(data).
 
         """
-        if data:
-            if not isinstance(data, bytes):
-                data = data.encode('utf8')
+        if not isinstance(data, bytes):
+            data = data.encode('utf8')
+        if size is None:
             size = len(data)
 
         if not filesync_info.can_add_to_send_buffer(len(data)):

--- a/adb_shell/exceptions.py
+++ b/adb_shell/exceptions.py
@@ -80,6 +80,12 @@ class InvalidResponseError(Exception):
     """
 
 
+class DevicePathInvalidError(Exception):
+    """A file command was passed an invalid path.
+
+    """
+
+
 class PushFailedError(Exception):
     """Pushing a file failed for some reason.
 

--- a/tests/test_adb_device.py
+++ b/tests/test_adb_device.py
@@ -519,6 +519,18 @@ class TestAdbDevice(unittest.TestCase):
         self.assertEqual(expected_result, self.device.list('/dir'))
         self.assertEqual(expected_bulk_write, self.device._transport._bulk_write)
 
+    def test_list_empty_path(self):
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.list("")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.list(b"")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.list(u"")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.list(None)
+        # Clear the `_bulk_read` buffer so that `self.tearDown()` passes
+        self.device._transport._bulk_read = b''
+
     def test_push_fail(self):
         self.assertTrue(self.device.connect())
         self.device._transport._bulk_write = b''
@@ -642,6 +654,18 @@ class TestAdbDevice(unittest.TestCase):
         with patch('adb_shell.adb_device.open', patchers.mock_open(read_data=filedata)), patch('os.path.isdir', lambda x: x == 'TEST_DIR/'), patch('os.listdir', return_value=['TEST_FILE1', 'TEST_FILE2']):
             self.device.push('TEST_DIR/', '/data', mtime=mtime)
 
+    def test_push_empty_path(self):
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.push("NOTHING", "")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.push("NOTHING", b"")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.push("NOTHING", u"")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.push("NOTHING", None)
+        # Clear the `_bulk_read` buffer so that `self.tearDown()` passes
+        self.device._transport._bulk_read = b''
+
     def test_pull_file(self):
         self.assertTrue(self.device.connect())
         self.device._transport._bulk_write = b''
@@ -690,6 +714,18 @@ class TestAdbDevice(unittest.TestCase):
             self.assertEqual(m.written, filedata)
             self.assertEqual(expected_bulk_write, self.device._transport._bulk_write)
 
+    def test_pull_empty_path(self):
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.pull("", "NOWHERE")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.pull(b"", "NOWHERE")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.pull(u"", "NOWHERE")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.pull(None, "NOWHERE")
+        # Clear the `_bulk_read` buffer so that `self.tearDown()` passes
+        self.device._transport._bulk_read = b''
+
     def test_stat(self):
         self.assertTrue(self.device.connect())
         self.device._transport._bulk_write = b''
@@ -709,6 +745,18 @@ class TestAdbDevice(unittest.TestCase):
 
         self.assertEqual((1, 2, 3), self.device.stat('/data'))
         self.assertEqual(expected_bulk_write, self.device._transport._bulk_write)
+
+    def test_stat_empty_path(self):
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.stat("")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.stat(b"")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.stat(u"")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            self.device.stat(None)
+        # Clear the `_bulk_read` buffer so that `self.tearDown()` passes
+        self.device._transport._bulk_read = b''
 
     # ======================================================================= #
     #                                                                         #

--- a/tests/test_adb_device_async.py
+++ b/tests/test_adb_device_async.py
@@ -555,6 +555,19 @@ class TestAdbDeviceAsync(unittest.TestCase):
         self.assertEqual(await self.device.list('/dir'), expected_result)
         self.assertEqual(self.device._transport._bulk_write, expected_bulk_write)
 
+    @awaiter
+    async def test_list_empty_path(self):
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.list("")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.list(b"")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.list(u"")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.list(None)
+        # Clear the `_bulk_read` buffer so that `self.tearDown()` passes
+        self.device._transport._bulk_read = b''
+
     @patchers.ASYNC_SKIPPER
     @awaiter
     async def test_push_fail(self):
@@ -688,6 +701,19 @@ class TestAdbDeviceAsync(unittest.TestCase):
         with patch('aiofiles.open', async_mock_open(read_data=filedata)), patch('os.path.isdir', lambda x: x == 'TEST_DIR/'), patch('os.listdir', return_value=['TEST_FILE1', 'TEST_FILE2']):
             await self.device.push('TEST_DIR/', '/data', mtime=mtime)
 
+    @awaiter
+    async def test_push_empty_path(self):
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.push("NOTHING", "")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.push("NOTHING", b"")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.push("NOTHING", u"")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.push("NOTHING", None)
+        # Clear the `_bulk_read` buffer so that `self.tearDown()` passes
+        self.device._transport._bulk_read = b''
+
     @patchers.ASYNC_SKIPPER
     @awaiter
     async def test_pull_file(self):
@@ -741,6 +767,19 @@ class TestAdbDeviceAsync(unittest.TestCase):
             self.assertEqual(self.device._transport._bulk_write, expected_bulk_write)
 
     @awaiter
+    async def test_pull_empty_path(self):
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.pull("", "NOWHERE")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.pull(b"", "NOWHERE")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.pull(u"", "NOWHERE")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.pull(None, "NOWHERE")
+        # Clear the `_bulk_read` buffer so that `self.tearDown()` passes
+        self.device._transport._bulk_read = b''
+
+    @awaiter
     async def test_stat(self):
         self.assertTrue(await self.device.connect())
         self.device._transport._bulk_write = b''
@@ -760,6 +799,19 @@ class TestAdbDeviceAsync(unittest.TestCase):
 
         self.assertEqual(await self.device.stat('/data'), (1, 2, 3))
         self.assertEqual(self.device._transport._bulk_write, expected_bulk_write)
+
+    @awaiter
+    async def test_stat_empty_path(self):
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.stat("")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.stat(b"")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.stat(u"")
+        with self.assertRaises(exceptions.DevicePathInvalidError):
+            await self.device.stat(None)
+        # Clear the `_bulk_read` buffer so that `self.tearDown()` passes
+        self.device._transport._bulk_read = b''
 
     # ======================================================================= #
     #                                                                         #


### PR DESCRIPTION
This change ensures that we can send filesync messages without breaking. IIRC this broke when I was doing some file `stat`ing.