### PR TITLE
Refactor timeouts

### DIFF
--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -1193,7 +1193,7 @@ class AdbDeviceTcp(AdbDevice):
     _banner : bytearray, bytes
         The hostname of the machine where the Python interpreter is currently running
     _default_transport_timeout_s : float, None
-        Default timeout in seconds for transport packets, or ``None``
+        Default timeout in seconds for TCP packets, or ``None``
     _maxdata : int
         Maximum amount of data in an ADB packet
     _transport : TcpTransport
@@ -1233,7 +1233,7 @@ class AdbDeviceUsb(AdbDevice):
     _banner : bytearray, bytes
         The hostname of the machine where the Python interpreter is currently running
     _default_transport_timeout_s : float, None
-        Default timeout in seconds for transport packets, or ``None``
+        Default timeout in seconds for USB packets, or ``None``
     _maxdata : int
         Maximum amount of data in an ADB packet
     _transport : UsbTransport

--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -90,12 +90,10 @@ class AdbDevice(object):
     transport : BaseTransport
         A user-provided transport for communicating with the device; must be an instance of a subclass of :class:`~adb_shell.transport.base_transport.BaseTransport`
     default_transport_timeout_s : float, None
-        TODO
+        Default timeout in seconds for transport packets, or ``None``
     banner : str, bytes, None
         The hostname of the machine where the Python interpreter is currently running; if
         it is not provided, it will be determined via ``socket.gethostname()``
-    default_transport_timeout_s : float, None
-        Default timeout in seconds for transport packets, or ``None``
 
     Raises
     ------
@@ -109,7 +107,7 @@ class AdbDevice(object):
     _banner : bytearray, bytes
         The hostname of the machine where the Python interpreter is currently running
     _default_transport_timeout_s : float, None
-        TODO
+        Default timeout in seconds for transport packets, or ``None``
     _maxdata: int
         Maximum amount of data in an ADB packet
     _transport : BaseTransport
@@ -1195,9 +1193,9 @@ class AdbDeviceTcp(AdbDevice):
     _banner : bytearray, bytes
         The hostname of the machine where the Python interpreter is currently running
     _default_transport_timeout_s : float, None
-        TODO
+        Default timeout in seconds for transport packets, or ``None``
     _maxdata : int
-        TODO
+        Maximum amount of data in an ADB packet
     _transport : TcpTransport
         The transport that is used to connect to the device
 
@@ -1235,9 +1233,9 @@ class AdbDeviceUsb(AdbDevice):
     _banner : bytearray, bytes
         The hostname of the machine where the Python interpreter is currently running
     _default_transport_timeout_s : float, None
-        TODO
+        Default timeout in seconds for transport packets, or ``None``
     _maxdata : int
-        TODO
+        Maximum amount of data in an ADB packet
     _transport : UsbTransport
         The transport that is used to connect to the device
 

--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -92,6 +92,8 @@ class AdbDevice(object):
     banner : str, bytes, None
         The hostname of the machine where the Python interpreter is currently running; if
         it is not provided, it will be determined via ``socket.gethostname()``
+    default_transport_timeout_s : float, None
+        Default timeout in seconds for transport packets, or ``None``
 
     Raises
     ------
@@ -111,7 +113,7 @@ class AdbDevice(object):
 
     """
 
-    def __init__(self, transport, banner=None):
+    def __init__(self, transport, default_transport_timeout_s=None, banner=None):
         if banner and not isinstance(banner, (bytes, bytearray)):
             self._banner = bytearray(banner, 'utf-8')
         else:
@@ -123,7 +125,25 @@ class AdbDevice(object):
         self._transport = transport
 
         self._available = False
+        self._default_transport_timeout_s = default_transport_timeout_s
         self._maxdata = constants.MAX_PUSH_DATA
+
+    # ======================================================================= #
+    #                                                                         #
+    #                       Properties & simple methods                       #
+    #                                                                         #
+    # ======================================================================= #
+    @property
+    def available(self):
+        """Whether or not an ADB connection to the device has been established.
+
+        Returns
+        -------
+        bool
+            ``self._available``
+
+        """
+        return self._available
 
     @property
     def max_chunk_size(self):
@@ -137,18 +157,27 @@ class AdbDevice(object):
         """
         return min(constants.MAX_CHUNK_SIZE, self._maxdata // 2) or constants.MAX_PUSH_DATA
 
-    @property
-    def available(self):
-        """Whether or not an ADB connection to the device has been established.
+    def _get_transport_timeout_s(self, transport_timeout_s):
+        """Use the provided ``transport_timeout_s`` if it is not ``None``; otherwise, use ``self._default_transport_timeout_s``
+
+        Parameters
+        ----------
+        transport_timeout_s : float, None
+            The potential transport timeout
 
         Returns
         -------
-        bool
-            ``self._available``
+        float
+            ``transport_timeout_s`` if it is not ``None``; otherwise, ``self._default_transport_timeout_s``
 
         """
-        return self._available
+        return transport_timeout_s if transport_timeout_s is not None else self._default_transport_timeout_s
 
+    # ======================================================================= #
+    #                                                                         #
+    #                             Close & Connect                             #
+    #                                                                         #
+    # ======================================================================= #
     def close(self):
         """Close the connection via the provided transport's ``close()`` method.
 
@@ -212,7 +241,7 @@ class AdbDevice(object):
 
         # 2. Send a ``b'CNXN'`` message
         msg = AdbMessage(constants.CNXN, constants.VERSION, constants.MAX_ADB_DATA, b'host::%s\0' % self._banner)
-        adb_info = _AdbTransactionInfo(None, None, transport_timeout_s, read_timeout_s)
+        adb_info = _AdbTransactionInfo(None, None, self._get_transport_timeout_s(transport_timeout_s), read_timeout_s)
         self._send(msg, adb_info)
 
         # 3. Unpack the ``cmd``, ``arg0``, ``arg1``, and ``banner`` fields from the response
@@ -297,7 +326,7 @@ class AdbDevice(object):
             The output of the ADB command as a string if ``decode`` is True, otherwise as bytes.
 
         """
-        adb_info = _AdbTransactionInfo(None, None, transport_timeout_s, read_timeout_s, timeout_s)
+        adb_info = _AdbTransactionInfo(None, None, self._get_transport_timeout_s(transport_timeout_s), read_timeout_s, timeout_s)
         if decode:
             return b''.join(self._streaming_command(service, command, adb_info)).decode('utf8')
         return b''.join(self._streaming_command(service, command, adb_info))
@@ -325,7 +354,7 @@ class AdbDevice(object):
             The line-by-line output of the ADB command as a string if ``decode`` is True, otherwise as bytes.
 
         """
-        adb_info = _AdbTransactionInfo(None, None, transport_timeout_s, read_timeout_s)
+        adb_info = _AdbTransactionInfo(None, None, self._get_transport_timeout_s(transport_timeout_s), read_timeout_s)
         stream = self._streaming_command(service, command, adb_info)
         if decode:
             for line in (stream_line.decode('utf8') for stream_line in stream):
@@ -438,7 +467,7 @@ class AdbDevice(object):
         if not self.available:
             raise exceptions.AdbConnectionError("ADB command not sent because a connection to the device has not been established.  (Did you call `AdbDevice.connect()`?)")
 
-        adb_info = _AdbTransactionInfo(None, None, transport_timeout_s, read_timeout_s)
+        adb_info = _AdbTransactionInfo(None, None, self._get_transport_timeout_s(transport_timeout_s), read_timeout_s)
         filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_LIST_FORMAT, maxdata=self._maxdata)
         self._open(b'sync:', adb_info)
 
@@ -478,7 +507,7 @@ class AdbDevice(object):
         if not self.available:
             raise exceptions.AdbConnectionError("ADB command not sent because a connection to the device has not been established.  (Did you call `AdbDevice.connect()`?)")
 
-        adb_info = _AdbTransactionInfo(None, None, transport_timeout_s, read_timeout_s)
+        adb_info = _AdbTransactionInfo(None, None, self._get_transport_timeout_s(transport_timeout_s), read_timeout_s)
         filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_PULL_FORMAT, maxdata=self._maxdata)
 
         with open(local_path, 'wb') as stream:
@@ -549,7 +578,7 @@ class AdbDevice(object):
             self.shell("mkdir " + device_path, transport_timeout_s, read_timeout_s)
 
         for _local_path, _device_path in zip(local_paths, device_paths):
-            adb_info = _AdbTransactionInfo(None, None, transport_timeout_s, read_timeout_s)
+            adb_info = _AdbTransactionInfo(None, None, self._get_transport_timeout_s(transport_timeout_s), read_timeout_s)
             filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_PUSH_FORMAT, maxdata=self._maxdata)
 
             with open(_local_path, 'rb') as stream:
@@ -639,7 +668,7 @@ class AdbDevice(object):
         if not self.available:
             raise exceptions.AdbConnectionError("ADB command not sent because a connection to the device has not been established.  (Did you call `AdbDevice.connect()`?)")
 
-        adb_info = _AdbTransactionInfo(None, None, transport_timeout_s, read_timeout_s)
+        adb_info = _AdbTransactionInfo(None, None, self._get_transport_timeout_s(transport_timeout_s), read_timeout_s)
         self._open(b'sync:', adb_info)
 
         filesync_info = _FileSyncTransactionInfo(constants.FILESYNC_STAT_FORMAT, maxdata=self._maxdata)
@@ -1167,7 +1196,7 @@ class AdbDeviceTcp(AdbDevice):
     """
 
     def __init__(self, host, port=5555, default_transport_timeout_s=None, banner=None):
-        transport = TcpTransport(host, port, default_transport_timeout_s)
+        transport = TcpTransport(host, port)
         super(AdbDeviceTcp, self).__init__(transport, banner)
 
 

--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -89,6 +89,8 @@ class AdbDevice(object):
     ----------
     transport : BaseTransport
         A user-provided transport for communicating with the device; must be an instance of a subclass of :class:`~adb_shell.transport.base_transport.BaseTransport`
+    default_transport_timeout_s : float, None
+        TODO
     banner : str, bytes, None
         The hostname of the machine where the Python interpreter is currently running; if
         it is not provided, it will be determined via ``socket.gethostname()``
@@ -106,6 +108,8 @@ class AdbDevice(object):
         Whether an ADB connection to the device has been established
     _banner : bytearray, bytes
         The hostname of the machine where the Python interpreter is currently running
+    _default_transport_timeout_s : float, None
+        TODO
     _maxdata: int
         Maximum amount of data in an ADB packet
     _transport : BaseTransport
@@ -1190,6 +1194,10 @@ class AdbDeviceTcp(AdbDevice):
         Whether an ADB connection to the device has been established
     _banner : bytearray, bytes
         The hostname of the machine where the Python interpreter is currently running
+    _default_transport_timeout_s : float, None
+        TODO
+    _maxdata : int
+        TODO
     _transport : TcpTransport
         The transport that is used to connect to the device
 
@@ -1197,7 +1205,7 @@ class AdbDeviceTcp(AdbDevice):
 
     def __init__(self, host, port=5555, default_transport_timeout_s=None, banner=None):
         transport = TcpTransport(host, port)
-        super(AdbDeviceTcp, self).__init__(transport, banner)
+        super(AdbDeviceTcp, self).__init__(transport, default_transport_timeout_s, banner)
 
 
 class AdbDeviceUsb(AdbDevice):
@@ -1226,6 +1234,10 @@ class AdbDeviceUsb(AdbDevice):
         Whether an ADB connection to the device has been established
     _banner : bytearray, bytes
         The hostname of the machine where the Python interpreter is currently running
+    _default_transport_timeout_s : float, None
+        TODO
+    _maxdata : int
+        TODO
     _transport : UsbTransport
         The transport that is used to connect to the device
 
@@ -1236,4 +1248,4 @@ class AdbDeviceUsb(AdbDevice):
             raise exceptions.InvalidTransportError("To enable USB support you must install this package via `pip install adb-shell[usb]`")
 
         transport = UsbTransport.find_adb(serial, port_path, default_transport_timeout_s)
-        super(AdbDeviceUsb, self).__init__(transport, banner)
+        super(AdbDeviceUsb, self).__init__(transport, default_transport_timeout_s, banner)

--- a/adb_shell/adb_device_async.py
+++ b/adb_shell/adb_device_async.py
@@ -84,6 +84,8 @@ class AdbDeviceAsync(object):
     ----------
     transport : BaseTransportAsync
         A user-provided transport for communicating with the device; must be an instance of a subclass of :class:`~adb_shell.transport.base_transport_async.BaseTransportAsync`
+    default_transport_timeout_s : float, None
+        TODO
     banner : str, bytes, None
         The hostname of the machine where the Python interpreter is currently running; if
         it is not provided, it will be determined via ``socket.gethostname()``
@@ -101,6 +103,8 @@ class AdbDeviceAsync(object):
         Whether an ADB connection to the device has been established
     _banner : bytearray, bytes
         The hostname of the machine where the Python interpreter is currently running
+    _default_transport_timeout_s : float, None
+        TODO
     _maxdata: int
         Maximum amount of data in an ADB packet
     _transport : BaseTransportAsync
@@ -1185,6 +1189,10 @@ class AdbDeviceTcpAsync(AdbDeviceAsync):
         Whether an ADB connection to the device has been established
     _banner : bytearray, bytes
         The hostname of the machine where the Python interpreter is currently running
+    _default_transport_timeout_s : float, None
+        TODO
+    _maxdata : int
+        TODO
     _transport : TcpTransportAsync
         The transport that is used to connect to the device
 
@@ -1192,4 +1200,4 @@ class AdbDeviceTcpAsync(AdbDeviceAsync):
 
     def __init__(self, host, port=5555, default_transport_timeout_s=None, banner=None):
         transport = TcpTransportAsync(host, port)
-        super(AdbDeviceTcpAsync, self).__init__(transport, banner)
+        super(AdbDeviceTcpAsync, self).__init__(transport, default_transport_timeout_s, banner)

--- a/adb_shell/adb_device_async.py
+++ b/adb_shell/adb_device_async.py
@@ -85,12 +85,10 @@ class AdbDeviceAsync(object):
     transport : BaseTransportAsync
         A user-provided transport for communicating with the device; must be an instance of a subclass of :class:`~adb_shell.transport.base_transport_async.BaseTransportAsync`
     default_transport_timeout_s : float, None
-        TODO
+        Default timeout in seconds for transport packets, or ``None``
     banner : str, bytes, None
         The hostname of the machine where the Python interpreter is currently running; if
         it is not provided, it will be determined via ``socket.gethostname()``
-    default_transport_timeout_s : float, None
-        Default timeout in seconds for transport packets, or ``None``
 
     Raises
     ------
@@ -104,7 +102,7 @@ class AdbDeviceAsync(object):
     _banner : bytearray, bytes
         The hostname of the machine where the Python interpreter is currently running
     _default_transport_timeout_s : float, None
-        TODO
+        Default timeout in seconds for transport packets, or ``None``
     _maxdata: int
         Maximum amount of data in an ADB packet
     _transport : BaseTransportAsync
@@ -1190,9 +1188,9 @@ class AdbDeviceTcpAsync(AdbDeviceAsync):
     _banner : bytearray, bytes
         The hostname of the machine where the Python interpreter is currently running
     _default_transport_timeout_s : float, None
-        TODO
+        Default timeout in seconds for TCP packets, or ``None``
     _maxdata : int
-        TODO
+        Maximum amount of data in an ADB packet
     _transport : TcpTransportAsync
         The transport that is used to connect to the device
 

--- a/adb_shell/transport/base_transport.py
+++ b/adb_shell/transport/base_transport.py
@@ -38,25 +38,25 @@ class BaseTransport(ABC):
         """
 
     @abstractmethod
-    def connect(self, transport_timeout_s=None):
+    def connect(self, transport_timeout_s):
         """Create a connection to the device.
 
         Parameters
         ----------
-        transport_timeout_s : float, None
+        transport_timeout_s : float
             A connection timeout
 
         """
 
     @abstractmethod
-    def bulk_read(self, numbytes, transport_timeout_s=None):
+    def bulk_read(self, numbytes, transport_timeout_s):
         """Read data from the device.
 
         Parameters
         ----------
         numbytes : int
             The maximum amount of data to be received
-        transport_timeout_s : float, None
+        transport_timeout_s : float
             A timeout for the read operation
 
         Returns
@@ -67,14 +67,14 @@ class BaseTransport(ABC):
         """
 
     @abstractmethod
-    def bulk_write(self, data, transport_timeout_s=None):
+    def bulk_write(self, data, transport_timeout_s):
         """Send data to the device.
 
         Parameters
         ----------
         data : bytes
             The data to be sent
-        transport_timeout_s : float, None
+        transport_timeout_s : float
             A timeout for the write operation
 
         Returns

--- a/adb_shell/transport/base_transport.py
+++ b/adb_shell/transport/base_transport.py
@@ -43,7 +43,7 @@ class BaseTransport(ABC):
 
         Parameters
         ----------
-        transport_timeout_s : float
+        transport_timeout_s : float, None
             A connection timeout
 
         """
@@ -56,7 +56,7 @@ class BaseTransport(ABC):
         ----------
         numbytes : int
             The maximum amount of data to be received
-        transport_timeout_s : float
+        transport_timeout_s : float, None
             A timeout for the read operation
 
         Returns
@@ -74,7 +74,7 @@ class BaseTransport(ABC):
         ----------
         data : bytes
             The data to be sent
-        transport_timeout_s : float
+        transport_timeout_s : float, None
             A timeout for the write operation
 
         Returns

--- a/adb_shell/transport/base_transport_async.py
+++ b/adb_shell/transport/base_transport_async.py
@@ -29,25 +29,25 @@ class BaseTransportAsync(ABC):
         """
 
     @abstractmethod
-    async def connect(self, transport_timeout_s=None):
+    async def connect(self, transport_timeout_s):
         """Create a connection to the device.
 
         Parameters
         ----------
-        transport_timeout_s : float, None
+        transport_timeout_s : float
             A connection timeout
 
         """
 
     @abstractmethod
-    async def bulk_read(self, numbytes, transport_timeout_s=None):
+    async def bulk_read(self, numbytes, transport_timeout_s):
         """Read data from the device.
 
         Parameters
         ----------
         numbytes : int
             The maximum amount of data to be received
-        transport_timeout_s : float, None
+        transport_timeout_s : float
             A timeout for the read operation
 
         Returns
@@ -58,14 +58,14 @@ class BaseTransportAsync(ABC):
         """
 
     @abstractmethod
-    async def bulk_write(self, data, transport_timeout_s=None):
+    async def bulk_write(self, data, transport_timeout_s):
         """Send data to the device.
 
         Parameters
         ----------
         data : bytes
             The data to be sent
-        transport_timeout_s : float, None
+        transport_timeout_s : float
             A timeout for the write operation
 
         Returns

--- a/adb_shell/transport/base_transport_async.py
+++ b/adb_shell/transport/base_transport_async.py
@@ -34,7 +34,7 @@ class BaseTransportAsync(ABC):
 
         Parameters
         ----------
-        transport_timeout_s : float
+        transport_timeout_s : float, None
             A connection timeout
 
         """
@@ -47,7 +47,7 @@ class BaseTransportAsync(ABC):
         ----------
         numbytes : int
             The maximum amount of data to be received
-        transport_timeout_s : float
+        transport_timeout_s : float, None
             A timeout for the read operation
 
         Returns
@@ -65,7 +65,7 @@ class BaseTransportAsync(ABC):
         ----------
         data : bytes
             The data to be sent
-        transport_timeout_s : float
+        transport_timeout_s : float, None
             A timeout for the write operation
 
         Returns

--- a/tests/test_tcp_transport.py
+++ b/tests/test_tcp_transport.py
@@ -15,7 +15,7 @@ class TestTcpTransport(unittest.TestCase):
         """
         self.transport = TcpTransport('host', 5555)
         with patchers.PATCH_CREATE_CONNECTION:
-            self.transport.connect()
+            self.transport.connect(transport_timeout_s=1)
 
     def tearDown(self):
         """Close the socket connection."""
@@ -38,12 +38,12 @@ class TestTcpTransport(unittest.TestCase):
         self.transport._connection._recv = b'TEST1TEST2'
 
         with patchers.PATCH_SELECT_SUCCESS:
-            self.assertEqual(self.transport.bulk_read(5), b'TEST1')
-            self.assertEqual(self.transport.bulk_read(5), b'TEST2')
+            self.assertEqual(self.transport.bulk_read(5, transport_timeout_s=1), b'TEST1')
+            self.assertEqual(self.transport.bulk_read(5, transport_timeout_s=1), b'TEST2')
 
         with patchers.PATCH_SELECT_FAIL:
             with self.assertRaises(TcpTimeoutException):
-                self.transport.bulk_read(4)
+                self.transport.bulk_read(4, transport_timeout_s=1)
 
     def test_close_oserror(self):
         """Test that an `OSError` exception is handled when closing the socket.
@@ -57,8 +57,8 @@ class TestTcpTransport(unittest.TestCase):
 
         """
         with patchers.PATCH_SELECT_SUCCESS:
-            self.transport.bulk_write(b'TEST')
+            self.transport.bulk_write(b'TEST', transport_timeout_s=1)
 
         with patchers.PATCH_SELECT_FAIL:
             with self.assertRaises(TcpTimeoutException):
-                self.transport.bulk_write(b'FAIL')
+                self.transport.bulk_write(b'FAIL', transport_timeout_s=1)

--- a/tests/test_tcp_transport_async.py
+++ b/tests/test_tcp_transport_async.py
@@ -29,12 +29,12 @@ class TestTcpTransportAsync(unittest.TestCase):
     @awaiter
     async def test_connect(self):
         with async_patch('asyncio.open_connection', return_value=(True, True)):
-            await self.transport.connect()
+            await self.transport.connect(transport_timeout_s=1)
 
     @awaiter
     async def test_connect_close(self):
         with async_patch('asyncio.open_connection', return_value=(FakeStreamReader(), FakeStreamWriter())):
-            await self.transport.connect()
+            await self.transport.connect(transport_timeout_s=1)
             self.assertIsNotNone(self.transport._writer)
 
         await self.transport.close()
@@ -44,7 +44,7 @@ class TestTcpTransportAsync(unittest.TestCase):
     @awaiter
     async def test_connect_close_catch_oserror(self):
         with async_patch('asyncio.open_connection', return_value=(FakeStreamReader(), FakeStreamWriter())):
-            await self.transport.connect()
+            await self.transport.connect(transport_timeout_s=1)
             self.assertIsNotNone(self.transport._writer)
 
         with patch('{}.FakeStreamWriter.close'.format(__name__), side_effect=OSError):
@@ -56,26 +56,26 @@ class TestTcpTransportAsync(unittest.TestCase):
     async def test_connect_with_timeout(self):
         with self.assertRaises(TcpTimeoutException):
             with async_patch('asyncio.open_connection', side_effect=asyncio.TimeoutError):
-                await self.transport.connect()
+                await self.transport.connect(transport_timeout_s=1)
 
     @awaiter
     async def test_bulk_read(self):
         with async_patch('asyncio.open_connection', return_value=(FakeStreamReader(), FakeStreamWriter())):
-            await self.transport.connect()
+            await self.transport.connect(transport_timeout_s=1)
 
-        self.assertEqual(await self.transport.bulk_read(4), b'TEST')
+        self.assertEqual(await self.transport.bulk_read(4, transport_timeout_s=1), b'TEST')
 
         with self.assertRaises(TcpTimeoutException):
             with patch('{}.FakeStreamReader.read'.format(__name__), side_effect=asyncio.TimeoutError):
-                await self.transport.bulk_read(4)
+                await self.transport.bulk_read(4, transport_timeout_s=1)
 
     @awaiter
     async def test_bulk_write(self):
         with async_patch('asyncio.open_connection', return_value=(FakeStreamReader(), FakeStreamWriter())):
-            await self.transport.connect()
+            await self.transport.connect(transport_timeout_s=1)
 
-        self.assertEqual(await self.transport.bulk_write(b'TEST'), 4)
+        self.assertEqual(await self.transport.bulk_write(b'TEST', transport_timeout_s=1), 4)
 
         with self.assertRaises(TcpTimeoutException):
             with patch('{}.FakeStreamWriter.write'.format(__name__), side_effect=asyncio.TimeoutError):
-                await self.transport.bulk_write(b'TEST')
+                await self.transport.bulk_write(b'TEST', transport_timeout_s=1)


### PR DESCRIPTION
# Breaking change

This updates the parameters for the `AdbDevice` and `AdbDeviceAsync` constructors; the constructors for their subclasses are unchanged. 