### PR TITLE
fix: Ensure `UsbReadFailedError` can be pickled

### DIFF
--- a/adb_shell/exceptions.py
+++ b/adb_shell/exceptions.py
@@ -115,11 +115,11 @@ class UsbReadFailedError(Exception):
 
     """
     def __init__(self, msg, usb_error):
-        super(UsbReadFailedError, self).__init__(msg)
+        super(UsbReadFailedError, self).__init__(msg, usb_error)
         self.usb_error = usb_error
 
     def __str__(self):
-        return '%s: %s' % (super(UsbReadFailedError, self).__str__(), str(self.usb_error))
+        return '%s: %s' % self.args
 
 
 class UsbWriteFailedError(Exception):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,37 @@
+import functools
+import inspect
+import pickle
+import unittest
+
+import adb_shell.exceptions
+
+try:
+    getargspec = inspect.getfullargspec
+except AttributeError:
+    getargspec = inspect.getargspec
+
+
+class TestExceptionSerialization(unittest.TestCase):
+    def __test_serialize_one_exc_cls(exc_cls):
+        # Work out how many args we need to instantiate this object
+        try:
+            exc_required_arity = len(getargspec(exc_cls.__init__).args)
+        except TypeError:
+            # In Python 2.7 this could be a slot wrapper which means `__init__`
+            # wasn't overridden by the exception subclass - use 0 arity.
+            exc_required_arity = 0
+        # Don't try to provide `self` - we assume strings will be fine here
+        fake_args = ("foo", ) * (exc_required_arity - 1)
+        # Instantiate the exception object and then attempt a serializion cycle
+        # using `pickle` - we mainly care about whether this blows up or not
+        exc_obj = exc_cls(*fake_args)
+        pickled_exc_data = pickle.dumps(exc_obj)
+        depickled_exc_obj = pickle.loads(pickled_exc_data)
+
+    for __obj in adb_shell.exceptions.__dict__.values():
+        if isinstance(__obj, type) and issubclass(__obj, BaseException):
+            __test_method = functools.partial(
+                __test_serialize_one_exc_cls, __obj
+            )
+            __test_name = "test_serialize_{}".format(__obj.__name__)
+            locals()[__test_name] = __test_method


### PR DESCRIPTION
This change ensures that the base `Exception` class is aware of the
`usb_error` arg which gets passed to the subclass, rather than
intercepting it. By doing so, we leverage the built-in `__reduce__()`
behaviour of `Exception` so that `UsbReadFailedError` can be pickled and
unpickled without blowing up.

This change causes a minor change to the representation of these
exceptions, However stringification remains unchanged. Previously:
```python
>>> e = adb_shell.exceptions.UsbReadFailedError("foo", usb1.USBError("bar"))
>>> str(e)
'foo: Unknown error [bar]'
>>> repr(e)
"UsbReadFailedError('foo')"
```

and with this change:
```python
>>> e = adb_shell.exceptions.UsbReadFailedError("foo", usb1.USBError("bar"))
>>> str(e)
'foo: Unknown error [bar]'
>>> repr(e)
"UsbReadFailedError('foo', USBErrorTimeout())"
```