### PR TITLE
improv: Use `USBContext()` as a context manager

### DIFF
--- a/adb_shell/transport/usb_transport.py
+++ b/adb_shell/transport/usb_transport.py
@@ -555,15 +555,15 @@ class UsbTransport(BaseTransport):   # pragma: no cover
             UsbTransport instances
 
         """
-        ctx = usb1.USBContext()
-        for device in ctx.getDeviceList(skip_on_error=True):
-            setting = setting_matcher(device)
-            if setting is None:
-                continue
+        with usb1.USBContext() as ctx:
+            for device in ctx.getDeviceList(skip_on_error=True):
+                setting = setting_matcher(device)
+                if setting is None:
+                    continue
 
-            transport = cls(device, setting, usb_info=usb_info, default_transport_timeout_s=default_transport_timeout_s)
-            if device_matcher is None or device_matcher(transport):
-                yield transport
+                transport = cls(device, setting, usb_info=usb_info, default_transport_timeout_s=default_transport_timeout_s)
+                if device_matcher is None or device_matcher(transport):
+                    yield transport
 
     @classmethod
     def _find_first(cls, setting_matcher, device_matcher=None, usb_info='', default_transport_timeout_s=None):


### PR DESCRIPTION
Per the deprecation warning at:
> https://github.com/vpelletier/python-libusb1/blob/master/usb1/__init__.py#L2068