### PR TITLE
Added storage the built wheel in order to allow downloading.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,3 +41,8 @@ jobs:
       run: |
         if python --version 2>&1 | grep -q "Python 2" || python --version 2>&1 | grep -q "Python 3.5" || python --version 2>&1 | grep -q "Python 3.6" ; then for synctest in $(cd tests && ls test*.py | grep -v async); do python -m unittest discover -s tests/ -t . -p "$synctest" || exit 1; done; fi
         if python --version 2>&1 | grep -q "Python 3.7" || python --version 2>&1 | grep -q "Python 3.8" || python --version 2>&1 | grep -q "Python 3.9" || python --version 2>&1 | grep -q "Python 3.10"; then coverage run --source adb_shell -m unittest discover -s tests/ -t . && coverage report -m && coveralls; fi
+    - name: Upload wheel as a workflow artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheel
+        path: dist/*.whl

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,8 @@ adb\_shell
 
 Documentation for this package can be found at https://adb-shell.readthedocs.io/.
 
+Prebuilt wheel can be downloaded from `nightly.link <https://nightly.link/JeffLIrion/adb_shell/workflows/python-package/master/wheel.zip>`_.
+
 This Python package implements ADB shell and FileSync functionality.  It originated from `python-adb <https://github.com/google/python-adb>`_.
 
 Installation


### PR DESCRIPTION
Added a link allowing to download the wheel built by the latest pipeline (though within a zip archive, IDK the way to disable it currently) without sign in to GitHub.