### PR TITLE
Reword PythonRSASigner docstring

### DIFF
--- a/adb_shell/auth/sign_pythonrsa.py
+++ b/adb_shell/auth/sign_pythonrsa.py
@@ -127,7 +127,7 @@ class PythonRSASigner(object):
     pub : str, None
         The contents of the public key file
     priv : str, None
-        The path to the private key
+        The contents of the private key file
 
     Attributes
     ----------


### PR DESCRIPTION
Hi. I was reading adb_shell's documentation and the example usage and from the example usage it seems that `adb_shell.auth.sign_pythonrsa.PythonRSASigner()` accepts the contents of the public and private keys in its initor. But the docstring says that it accepts path to the private key and the contetns of the public key which is strange. I have assumed that this is an error and I have fixed it in this PR.