### PR TITLE
Wrap partial in enum.member for Python 3.11+

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: [3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v2

--- a/tests/async_wrapper.py
+++ b/tests/async_wrapper.py
@@ -1,5 +1,6 @@
 import asyncio
 import warnings
+import sys
 
 
 
@@ -10,6 +11,9 @@ def _await(coro):
     with warnings.catch_warnings(record=True) as warns:
         ret = loop.run_until_complete(coro)
         loop.close()
+
+        for warn in warns:
+            print(warn.message, file=sys.stderr)
 
         if warns:
             raise RuntimeError

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -2,11 +2,15 @@ import functools
 import inspect
 import pickle
 import re
+import sys
 import unittest
 try:
     from unittest import mock
 except ImportError:
     import mock
+
+if sys.version_info >= (3, 11):
+    from enum import member
 
 import adb_shell.exceptions
 
@@ -40,9 +44,14 @@ class TestExceptionSerialization(unittest.TestCase):
 
     for __obj in adb_shell.exceptions.__dict__.values():
         if isinstance(__obj, type) and issubclass(__obj, BaseException):
-            __test_method = functools.partial(
-                __test_serialize_one_exc_cls, __obj
-            )
+            if sys.version_info >= (3, 11):
+                __test_method = member(functools.partial(
+                    __test_serialize_one_exc_cls, __obj
+                ))
+            else:
+                __test_method = functools.partial(
+                    __test_serialize_one_exc_cls, __obj
+                )
             __test_name = "test_serialize_{}".format(__obj.__name__)
             locals()[__test_name] = __test_method
 


### PR DESCRIPTION
Fixes the following warning and the resulting test errors on Python 3.13.

> functools.partial will be a method descriptor in future Python versions;
> wrap it in enum.member() if you want to preserve the old behavior