### PR TITLE
Adds shell protocol support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,9 @@ Example Usage
    response1 = device1.shell('echo TEST1')
    response2 = device2.shell('echo TEST2')
 
+   # If the device supports the newer "shell protocol", you can also obtain individual streams
+   response3 = device1.shell_v2('echo TEST1')
+
 
 Generate ADB Key Files
 **********************

--- a/adb_shell/adb_device.py
+++ b/adb_shell/adb_device.py
@@ -229,7 +229,8 @@ class _AdbIOManager(object):
 
             # 4. If ``cmd`` is not ``b'AUTH'``, then authentication is not necesary and so we are done
             if cmd != constants.AUTH:
-                return True, maxdata
+                # TODO confirm that a rooted device will return device features here
+                return True, maxdata, True if constants.SHELL_V2_FEATURE in banner2 else False
 
             # 5. If no ``rsa_keys`` are provided, raise an exception
             if not rsa_keys:
@@ -248,12 +249,12 @@ class _AdbIOManager(object):
                 msg = AdbMessage(constants.AUTH, constants.AUTH_SIGNATURE, 0, signed_token)
                 self._send(msg, adb_info)
 
-                # 6.3. Read the response from the device
+                # 6.3. Read the response from the device, which will include the device's feature list
                 cmd, arg0, maxdata, banner2 = self._read_expected_packet_from_device([constants.CNXN, constants.AUTH], adb_info)
 
                 # 6.4. If ``cmd`` is ``b'CNXN'``, we are done
                 if cmd == constants.CNXN:
-                    return True, maxdata
+                    return True, maxdata, True if constants.SHELL_V2_FEATURE in banner2 else False
 
             # 7. None of the keys worked, so send ``rsa_keys[0]``'s public key; if the response does not time out, we must have connected successfully
             pubkey = rsa_keys[0].GetPublicKey()
@@ -267,8 +268,9 @@ class _AdbIOManager(object):
             self._send(msg, adb_info)
 
             adb_info.transport_timeout_s = auth_timeout_s
-            _, _, maxdata, _ = self._read_expected_packet_from_device([constants.CNXN], adb_info)
-            return True, maxdata
+            # TODO confirm device features are sent during type 3 authentication
+            _, _, maxdata, banner2 = self._read_expected_packet_from_device([constants.CNXN], adb_info)
+            return True, maxdata, True if constants.SHELL_V2_FEATURE in banner2 else False
 
     def read(self, expected_cmds, adb_info, allow_zeros=False):
         """Read packets from the device until we get an expected packet type.
@@ -672,7 +674,7 @@ class AdbDevice(object):
         self._available = False
 
         # Use the IO manager to connect
-        self._available, self._maxdata = self._io_manager.connect(self._banner, rsa_keys, auth_timeout_s, auth_callback, adb_info)
+        self._available, self._maxdata, self._shell_v2_supported = self._io_manager.connect(self._banner, rsa_keys, auth_timeout_s, auth_callback, adb_info)
 
         return self._available
 
@@ -838,6 +840,73 @@ class AdbDevice(object):
             raise exceptions.AdbConnectionError("ADB command not sent because a connection to the device has not been established.  (Did you call `AdbDevice.connect()`?)")
 
         return self._service(b'shell', command.encode('utf8'), transport_timeout_s, read_timeout_s, timeout_s, decode)
+
+    def shell_v2(self, command, transport_timeout_s=None, read_timeout_s=constants.DEFAULT_READ_TIMEOUT_S, timeout_s=None, decode=True):
+        """
+        Send an ADB shell command to the device, using the shell protocol.
+
+        The shell protocol is able to separate stdout/stderr streams, as well as provide a return code from the called process.
+
+        Parameters
+        ----------
+        command : str
+            The shell command that will be sent
+        transport_timeout_s : float, None
+            Timeout in seconds for sending and receiving data, or ``None``; see :meth:`BaseTransport.bulk_read() <adb_shell.transport.base_transport.BaseTransport.bulk_read>`
+            and :meth:`BaseTransport.bulk_write() <adb_shell.transport.base_transport.BaseTransport.bulk_write>`
+        read_timeout_s : float
+            The total time in seconds to wait for a ``b'CLSE'`` or ``b'OKAY'`` command in :meth:`_AdbIOManager.read`
+        timeout_s : float, None
+            The total time in seconds to wait for the ADB command to finish
+        decode : bool
+            Whether to decode the output to utf8 before returning
+
+        Returns
+        -------
+        dict
+            A dict representing the result of the ADB shell command. Dictionary keys are 'stdout', 'stderr', and 'return_code'. If ``decode`` is True,
+            stdout/stderr will be returned as strings - otherwise as bytes.
+
+        """
+        if not self.available:
+            raise exceptions.AdbConnectionError("ADB command not sent because a connection to the device has not been established.  (Did you call `AdbDevice.connect()`?)")
+
+        if not self._shell_v2_supported:
+            raise exceptions.AdbCommandFailureException("ADB shell_v2 service is not supported on this device.")
+
+        # For shell_v2 calls, we force decode to be False, so that we can separate out the streams using the raw bytes
+        shell_v2_result = self._service(b'shell,v2', command.encode('utf8'), transport_timeout_s, read_timeout_s, timeout_s, False)
+
+        data = BytesIO(shell_v2_result)
+        stdout = b''
+        stderr = b''
+        return_code: int = None
+        while True:
+            header = data.read(constants.SHELL_V2_HEADER_LENGTH)
+            if len(header) < constants.SHELL_V2_HEADER_LENGTH:
+                if len(header) != 0:
+                    _LOGGER.warning(f'ADB shell output contained unprocessed data: {header}')
+                break
+            output_fd, output_len = struct.unpack(constants.V2_RESPONSE_FORMAT, header)
+            output = data.read(output_len)
+
+            if output_fd == constants.KID_STDOUT:
+                stdout += output
+            elif output_fd == constants.KID_STDERR:
+                stderr += output
+            elif output_fd == constants.KID_EXIT:
+                if return_code is not None:
+                    _LOGGER.warning('Multiple return codes found for a single shell execution')
+                # Return code is a single byte
+                return_code = output[0]
+            else:
+                _LOGGER.warning(b'shell v2 output was not processed correctly: %s%s' % (header, output))
+
+        return {
+            'stdout': stdout.decode('utf8', _DECODE_ERRORS) if decode else stdout,
+            'stderr': stderr.decode('utf8', _DECODE_ERRORS) if decode else stderr,
+            'return_code': return_code
+        }
 
     def streaming_shell(self, command, transport_timeout_s=None, read_timeout_s=constants.DEFAULT_READ_TIMEOUT_S, decode=True):
         """Send an ADB shell command to the device, yielding each line of output.

--- a/adb_shell/constants.py
+++ b/adb_shell/constants.py
@@ -36,6 +36,15 @@ SUBCLASS = 0x42
 #: From adb.h
 PROTOCOL = 0x01
 
+#: From shell_service.h
+KID_STDOUT = 1
+
+#: From shell_service.h
+KID_STDERR = 2
+
+#: From shell_service.h
+KID_EXIT = 3
+
 #: ADB protocol version.
 VERSION = 0x01000000
 
@@ -60,6 +69,9 @@ AUTH_SIGNATURE = 2
 
 #: AUTH constant for ``arg0``
 AUTH_RSAPUBLICKEY = 3
+
+#: For shell_v2 calls, there is a five byte header for each data segment
+SHELL_V2_HEADER_LENGTH = 5
 
 AUTH = b'AUTH'
 CLSE = b'CLSE'
@@ -112,6 +124,9 @@ FILESYNC_PUSH_FORMAT = b'<2I'
 #: The format for FileSync "stat" messages
 FILESYNC_STAT_FORMAT = b'<4I'
 
+# The format for a "shell_v2" response
+V2_RESPONSE_FORMAT = b'<BI'
+
 #: The size of an ADB message
 MESSAGE_SIZE = struct.calcsize(MESSAGE_FORMAT)
 
@@ -120,3 +135,6 @@ DEFAULT_AUTH_TIMEOUT_S = 10.
 
 #: Default total timeout (in s) for reading data from the device
 DEFAULT_READ_TIMEOUT_S = 10.
+
+#: Feature set for devices that support the shell protocol
+SHELL_V2_FEATURE = b'shell_v2'

--- a/tests/patchers.py
+++ b/tests/patchers.py
@@ -12,17 +12,21 @@ from adb_shell import constants
 from adb_shell.adb_message import AdbMessage
 from adb_shell.transport.tcp_transport import TcpTransport
 
+test_features = b'features=abb_exec,fixed_push_symlink_timestamp,abb,stat_v2,apex,fixed_push_mkdir,cmd'
+test_features_shellv2_supported = test_features + b',shell_v2'
 
 ASYNC_SKIPPER=unittest.skipIf(sys.version_info.major < 3 or sys.version_info.minor < 7, "Async functionality requires Python 3.7+")
 
-MSG_CONNECT = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=constants.MAX_LEGACY_ADB_DATA, data=b'host::unknown\0')
+MSG_CONNECT = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=constants.MAX_LEGACY_ADB_DATA, data=b'host::%s\0' % test_features)
+MSG_CONNECT_FEATURES = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=constants.MAX_LEGACY_ADB_DATA, data=b'host::%s\0' % test_features_shellv2_supported)
 MSG_CONNECT_WITH_AUTH_INVALID = AdbMessage(command=constants.AUTH, arg0=0, arg1=0, data=b'host::unknown\0')
 MSG_CONNECT_WITH_AUTH1 = AdbMessage(command=constants.AUTH, arg0=constants.AUTH_TOKEN, arg1=0, data=b'host::unknown\0')
-MSG_CONNECT_WITH_AUTH2 = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=2*constants.MAX_LEGACY_ADB_DATA, data=b'host::unknown\0')
+MSG_CONNECT_WITH_AUTH2 = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=2*constants.MAX_LEGACY_ADB_DATA, data=b'host::%s\0' % test_features)
 MSG_CONNECT_WITH_AUTH_NEW_KEY2 = AdbMessage(command=constants.AUTH, arg0=0, arg1=0, data=b'host::unknown\0')
-MSG_CONNECT_WITH_AUTH_NEW_KEY3 = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=3*constants.MAX_LEGACY_ADB_DATA, data=b'host::unknown\0')
+MSG_CONNECT_WITH_AUTH_NEW_KEY3 = AdbMessage(command=constants.CNXN, arg0=constants.PROTOCOL, arg1=3*constants.MAX_LEGACY_ADB_DATA, data=b'host::%s\0' % test_features)
 
 BULK_READ_LIST = [MSG_CONNECT.pack(), MSG_CONNECT.data]
+BULK_READ_LIST_WITH_SHELLV2_FEATURE = [MSG_CONNECT_FEATURES.pack(), MSG_CONNECT_FEATURES.data]
 BULK_READ_LIST_WITH_AUTH_INVALID = [MSG_CONNECT_WITH_AUTH_INVALID.pack(), MSG_CONNECT_WITH_AUTH_INVALID.data]
 BULK_READ_LIST_WITH_AUTH = [MSG_CONNECT_WITH_AUTH1.pack(), MSG_CONNECT_WITH_AUTH1.data, MSG_CONNECT_WITH_AUTH2.pack(), MSG_CONNECT_WITH_AUTH2.data]
 BULK_READ_LIST_WITH_AUTH_NEW_KEY = [MSG_CONNECT_WITH_AUTH1.pack(), MSG_CONNECT_WITH_AUTH1.data, MSG_CONNECT_WITH_AUTH_NEW_KEY2.pack(), MSG_CONNECT_WITH_AUTH_NEW_KEY2.data, MSG_CONNECT_WITH_AUTH_NEW_KEY3.pack(), MSG_CONNECT_WITH_AUTH_NEW_KEY3.data]


### PR DESCRIPTION
## Summary
Hello @JeffLIrion ! I've been making use of your adb-shell project (thanks for the work on that), and realized there was a feature I could really use. It seems like others are looking for this change as well, and I thought instead of just asking for it to be done, I'd try offering a contribution via a PR:

This PR adds support for making use of the newer "shell protocol" service which can return separate stdout/stderr streams, as well as return exit code information from the shell.

## Changes Made
- Added new **shell_v2** function to AdbDevice and AdbDeviceAsync
- Added logic to parse whether device supports this style call in **connect** method

Here is what it looks like in action:
```
>>> device1.shell_v2('echo TEST')
{'stdout': 'TEST\n', 'stderr': '', 'return_code': 0}

>>> device1.shell_v2('ls /data/local/tmp/testing/existing_file /data/local/tmp/testing/does_not_exist')
{'stdout': '/data/local/tmp/testing/existing_file\n', 'stderr': 'ls: /data/local/tmp/testing/does_not_exist: No such file or directory\n', 'return_code': 1}
```

## Related Issue
Addresses #217 

## Checklist
- [x] Changes tested locally on my personal device
- [x] Unit tests added
- [x] README updated
- [ ] Added TODOs where confirmation is needed for devices I could not test
- [ ] Async version of the code stubbed out, but am not super familiar with using async (you may want to double check my changes there)

Do you think this is a candidate for getting merged to adb-shell main? It would extremely useful for me, if it could get merged/tagged (in some form or another.) Open to any suggestions/changes you would have.